### PR TITLE
Add ASCII default style

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -5,6 +5,113 @@ import (
 )
 
 var (
+	// ASCIIStyleConfig uses only ASCII characters.
+	ASCIIStyleConfig = ansi.StyleConfig{
+		Document: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				BlockPrefix: "\n",
+				BlockSuffix: "\n",
+			},
+			Indent: uintPtr(2),
+		},
+		BlockQuote: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{},
+			Indent:         uintPtr(1),
+			IndentToken:    stringPtr("| "),
+		},
+		Paragraph: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{},
+		},
+		List: ansi.StyleList{
+			StyleBlock: ansi.StyleBlock{
+				StylePrimitive: ansi.StylePrimitive{},
+			},
+			LevelIndent: 4,
+		},
+		Heading: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				BlockSuffix: "\n",
+			},
+		},
+		H1: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "# ",
+			},
+		},
+		H2: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "## ",
+			},
+		},
+		H3: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "### ",
+			},
+		},
+		H4: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "#### ",
+			},
+		},
+		H5: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "##### ",
+			},
+		},
+		H6: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "###### ",
+			},
+		},
+		Strikethrough: ansi.StylePrimitive{
+			BlockPrefix: "~~",
+			BlockSuffix: "~~",
+		},
+		Emph: ansi.StylePrimitive{
+			BlockPrefix: "*",
+			BlockSuffix: "*",
+		},
+		Strong: ansi.StylePrimitive{
+			BlockPrefix: "**",
+			BlockSuffix: "**",
+		},
+		HorizontalRule: ansi.StylePrimitive{
+			Format: "\n--------\n",
+		},
+		Item: ansi.StylePrimitive{
+			BlockPrefix: "• ",
+		},
+		Enumeration: ansi.StylePrimitive{
+			BlockPrefix: ". ",
+		},
+		Task: ansi.StyleTask{
+			Ticked:   "[x] ",
+			Unticked: "[ ] ",
+		},
+		ImageText: ansi.StylePrimitive{
+			Format: "Image: {{.text}} →",
+		},
+		Code: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				BlockPrefix: "`",
+				BlockSuffix: "`",
+			},
+		},
+		CodeBlock: ansi.StyleCodeBlock{
+			StyleBlock: ansi.StyleBlock{
+				Margin: uintPtr(2),
+			},
+		},
+		Table: ansi.StyleTable{
+			CenterSeparator: stringPtr("+"),
+			ColumnSeparator: stringPtr("|"),
+			RowSeparator:    stringPtr("-"),
+		},
+		DefinitionDescription: ansi.StylePrimitive{
+			BlockPrefix: "\n* ",
+		},
+	}
+
 	// DarkStyleConfig is the default dark style.
 	DarkStyleConfig = ansi.StyleConfig{
 		Document: ansi.StyleBlock{
@@ -624,6 +731,7 @@ var (
 
 	// DefaultStyles are the default styles.
 	DefaultStyles = map[string]*ansi.StyleConfig{
+		"ascii":  &ASCIIStyleConfig,
 		"dark":   &DarkStyleConfig,
 		"light":  &LightStyleConfig,
 		"notty":  &NoTTYStyleConfig,

--- a/styles/ascii.json
+++ b/styles/ascii.json
@@ -1,0 +1,87 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "indent": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "| "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 4
+  },
+  "heading": {
+    "block_suffix": "\n"
+  },
+  "h1": {
+    "prefix": "# "
+  },
+  "h2": {
+    "prefix": "## "
+  },
+  "h3": {
+    "prefix": "### "
+  },
+  "h4": {
+    "prefix": "#### "
+  },
+  "h5": {
+    "prefix": "##### "
+  },
+  "h6": {
+    "prefix": "###### "
+  },
+  "text": {},
+  "strikethrough": {
+    "block_prefix": "~~",
+    "block_suffix": "~~"
+  },
+  "emph": {
+    "block_prefix": "*",
+    "block_suffix": "*"
+  },
+  "strong": {
+    "block_prefix": "**",
+    "block_suffix": "**"
+  },
+  "hr": {
+    "format": "\n--------\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[x] ",
+    "unticked": "[ ] "
+  },
+  "link": {},
+  "link_text": {},
+  "image": {},
+  "image_text": {
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "block_prefix": "`",
+    "block_suffix": "`"
+  },
+  "code_block": {
+    "margin": 2
+  },
+  "table": {
+    "center_separator": "+",
+    "column_separator": "|",
+    "row_separator": "-"
+  },
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n* "
+  },
+  "html_block": {},
+  "html_span": {}
+}


### PR DESCRIPTION
This PR adds a default style that uses only ASCII characters. This is a good fallback style for situations where the terminal and/or localization might not be correctly configured.