### PR TITLE
Enable golangci-lint in GitHub workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,6 +29,12 @@ jobs:
       run: go test ./...
       if: matrix.platform != 'windows-latest'
 
+    - name: Linter
+      uses: docker://matoous/golangci-lint-action:v1.1.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: matrix.go-version == '1.13.x' && matrix.platform == 'ubuntu-latest'
+
     - name: Coverage
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses `matoous/golangci-lint-action@v1.1.0` to annotate changes.