### PR TITLE
GLAMOUR_STYLE environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ fmt.Print(out)
 You can find all available default styles in our [gallery](https://github.com/charmbracelet/glamour/tree/master/styles/gallery).
 Want to create your own style? [Learn how!](https://github.com/charmbracelet/glamour/tree/master/styles)
 
+There are a few options for using a custom style:
+1. Call `glamour.Render(inputText, "desiredStyle")`
+1. Set the `GLAMOUR_STYLE` environment variable to your desired default style or a file location for a style and call `glamour.RenderWithEnvironmentConfig(inputText)`
+1. Set the `GLAMOUR_STYLE` environment variable and pass `glamour.WithEnvironmentConfig()` to your custom renderer
+
 
 ## Glamourous Projects
 

--- a/glamour.go
+++ b/glamour.go
@@ -36,6 +36,14 @@ func Render(in string, stylePath string) (string, error) {
 	return string(b), err
 }
 
+// Render initializes a new TermRenderer and renders a markdown with a specific
+// style defined by the GLAMOUR_STYLE environment variable.
+func RenderWithConfig(in string) (string, error) {
+	stylePath := os.Getenv("GLAMOUR_STYLE")
+	b, err := RenderBytes([]byte(in), stylePath)
+	return string(b), err
+}
+
 // RenderBytes initializes a new TermRenderer and renders a markdown with a
 // specific style.
 func RenderBytes(in []byte, stylePath string) ([]byte, error) {

--- a/glamour.go
+++ b/glamour.go
@@ -36,11 +36,10 @@ func Render(in string, stylePath string) (string, error) {
 	return string(b), err
 }
 
-// Render initializes a new TermRenderer and renders a markdown with a specific
-// style defined by the GLAMOUR_STYLE environment variable.
-func RenderWithConfig(in string) (string, error) {
-	stylePath := os.Getenv("GLAMOUR_STYLE")
-	b, err := RenderBytes([]byte(in), stylePath)
+// RenderWithEnvironmentConfig initializes a new TermRenderer and renders a
+// markdown with a specific style defined by the GLAMOUR_STYLE environment variable.
+func RenderWithEnvironmentConfig(in string) (string, error) {
+	b, err := RenderBytes([]byte(in), getGlamourStyleFromEnvironment())
 	return string(b), err
 }
 
@@ -123,6 +122,12 @@ func WithStandardStyle(style string) TermRendererOption {
 // or light style, depending on the terminal's background color at run-time.
 func WithAutoStyle() TermRendererOption {
 	return WithStandardStyle("auto")
+}
+
+// WithEnvironmentConfig sets a TermRenderer's styles based on the
+// GLAMOUR_STYLE environment variable.
+func WithEnvironmentConfig() TermRendererOption {
+	return WithStylePath(getGlamourStyleFromEnvironment())
 }
 
 // WithStylePath sets a TermRenderer's style from stylePath. stylePath is first
@@ -213,6 +218,15 @@ func (tr *TermRenderer) RenderBytes(in []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	err := tr.md.Convert(in, &buf)
 	return buf.Bytes(), err
+}
+
+func getGlamourStyleFromEnvironment() string {
+	glamourStyle := os.Getenv("GLAMOUR_STYLE")
+	if len(glamourStyle) == 0 {
+		glamourStyle = "auto"
+	}
+
+	return glamourStyle
 }
 
 func getDefaultStyle(style string) (*ansi.StyleConfig, error) {

--- a/glamour.go
+++ b/glamour.go
@@ -39,7 +39,7 @@ func Render(in string, stylePath string) (string, error) {
 // RenderWithEnvironmentConfig initializes a new TermRenderer and renders a
 // markdown with a specific style defined by the GLAMOUR_STYLE environment variable.
 func RenderWithEnvironmentConfig(in string) (string, error) {
-	b, err := RenderBytes([]byte(in), getGlamourStyleFromEnvironment())
+	b, err := RenderBytes([]byte(in), getEnvironmentStyle())
 	return string(b), err
 }
 
@@ -127,7 +127,7 @@ func WithAutoStyle() TermRendererOption {
 // WithEnvironmentConfig sets a TermRenderer's styles based on the
 // GLAMOUR_STYLE environment variable.
 func WithEnvironmentConfig() TermRendererOption {
-	return WithStylePath(getGlamourStyleFromEnvironment())
+	return WithStylePath(getEnvironmentStyle())
 }
 
 // WithStylePath sets a TermRenderer's style from stylePath. stylePath is first
@@ -220,7 +220,7 @@ func (tr *TermRenderer) RenderBytes(in []byte) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-func getGlamourStyleFromEnvironment() string {
+func getEnvironmentStyle() string {
 	glamourStyle := os.Getenv("GLAMOUR_STYLE")
 	if len(glamourStyle) == 0 {
 		glamourStyle = "auto"

--- a/glamour_test.go
+++ b/glamour_test.go
@@ -104,6 +104,13 @@ func TestStyles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	_, err = NewTermRenderer(
+		WithEnvironmentConfig(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestRenderHelpers(t *testing.T) {

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk=
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f h1:5CjVwnuUcp5adK4gmY6i72gpVFVnZDP2h5TmPScB6u4=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=


### PR DESCRIPTION
This PR adds functions to pull user style configs from the user's terminal environment to prevent having to pass the style every time a program utilizing `glamour` is called (e.g. `glow -s ~/.dotfiles/glow/nord.json --pager README.md`).

I added in a "test" to make sure the custom renderer works. I can flesh out the tests more by generating a test Markdown file with embedded color information similar to existing tests if you'd like. I held off for now because I implemented the environment checking with minimal new code and it worked based on my local fiddling.

For context, this PR was originally discussed/designed [in this PR on the Glow project](https://github.com/charmbracelet/glow/pull/147).