### PR TITLE
Fix resolving of absolute URLs

### DIFF
--- a/ansi/image.go
+++ b/ansi/image.go
@@ -25,7 +25,7 @@ func (e *ImageElement) Render(w io.Writer, ctx RenderContext) error {
 	}
 	if len(e.URL) > 0 {
 		el := &BaseElement{
-			Token:  resolveRelativeURL(e.BaseURL, e.URL),
+			Token:  resolveURL(e.BaseURL, e.URL),
 			Prefix: " ",
 			Style:  ctx.options.Styles.Image,
 		}

--- a/ansi/link.go
+++ b/ansi/link.go
@@ -64,7 +64,7 @@ func (e *LinkElement) Render(w io.Writer, ctx RenderContext) error {
 		}
 
 		el := &BaseElement{
-			Token:  resolveRelativeURL(e.BaseURL, e.URL),
+			Token:  resolveURL(e.BaseURL, e.URL),
 			Prefix: pre,
 			Style:  style,
 		}

--- a/ansi/renderer.go
+++ b/ansi/renderer.go
@@ -3,7 +3,6 @@ package ansi
 import (
 	"io"
 	"net/url"
-	"strings"
 
 	"github.com/muesli/termenv"
 	east "github.com/yuin/goldmark-emoji/ast"
@@ -149,7 +148,7 @@ func isChild(node ast.Node) bool {
 	return false
 }
 
-func resolveRelativeURL(baseURL string, rel string) string {
+func resolveURL(baseURL string, rel string) string {
 	u, err := url.Parse(rel)
 	if err != nil {
 		return rel
@@ -157,7 +156,6 @@ func resolveRelativeURL(baseURL string, rel string) string {
 	if u.IsAbs() {
 		return rel
 	}
-	u.Path = strings.TrimPrefix(u.Path, "/")
 
 	base, err := url.Parse(baseURL)
 	if err != nil {


### PR DESCRIPTION
URL resolver treats all URLs as relative 🤔

The thing is, that `resolveRelativeURL()` is not only used for relative URLs.
This means, a link with an absolute URL like `/foo/bar.jpg` would be resolved as relative.

I'm not sure what the check for a leading `/` was meant for, this was in the repo from the first commit on (in a different variant with the same issue)..