### PR TITLE
fix issue where lists that didn't start at 1 were not respected

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -156,6 +156,7 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		return Element{
 			Exiting: post,
 			Renderer: &ItemElement{
+				IsOrdered: node.Parent().(*ast.List).IsOrdered(),
 				Enumeration: e,
 			},
 		}

--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -129,6 +129,9 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		}
 		if node.Parent().(*ast.List).IsOrdered() {
 			e = l
+			if node.Parent().(*ast.List).Start != 1 {
+				e += uint(node.Parent().(*ast.List).Start) - 1
+			}
 		}
 
 		post := "\n"

--- a/ansi/listitem.go
+++ b/ansi/listitem.go
@@ -7,12 +7,13 @@ import (
 
 // An ItemElement is used to render items inside a list.
 type ItemElement struct {
+	IsOrdered   bool
 	Enumeration uint
 }
 
 func (e *ItemElement) Render(w io.Writer, ctx RenderContext) error {
 	var el *BaseElement
-	if e.Enumeration > 0 {
+	if e.IsOrdered {
 		el = &BaseElement{
 			Style:  ctx.options.Styles.Enumeration,
 			Prefix: strconv.FormatInt(int64(e.Enumeration), 10),

--- a/styles/examples/ordered_list.md
+++ b/styles/examples/ordered_list.md
@@ -1,0 +1,3 @@
+3. 3 is first and numbered 3
+4. 4 is second and numbered 4
+10. ten is third and numbered 5

--- a/styles/examples/ordered_list.style
+++ b/styles/examples/ordered_list.style
@@ -1,0 +1,8 @@
+{
+    "list": {
+        "level_indent": 1
+    },
+    "enumeration": {
+        "block_prefix": ". "
+    }
+}

--- a/testdata/ordered_list.test
+++ b/testdata/ordered_list.test
@@ -1,0 +1,4 @@
+                                                                                
+3. 3 is first and numbered 3                                                    
+4. 4 is second and numbered 4                                                   
+5. ten is third and numbered 5                                                  


### PR DESCRIPTION
The problem is more thoroughly elaborated in [this issue](https://github.com/maaslalani/slides/issues/88) for a depending project.  The tl;dr is that most/all markdown processors will respect the first number in a numbered list, and ignore all subsequent values.  The commonmark reference implementation [implements this](https://spec.commonmark.org/dingus/?text=4.%20four%0A5.%20five%0A%0A), and github flavored markdown respects this as well.

This change is to recalculate the list enumeration value based on the starting number in the list.  It has been manually tested, and lists starting at 0 are rendered correctly as well.

Sample showing fixed behavior:
![image](https://user-images.githubusercontent.com/5506073/128448630-eb077cce-468f-40c6-83a5-56835d741c01.png)

Sample showing fixed behavior with 0:
![image](https://user-images.githubusercontent.com/5506073/128449013-c9ce38a2-ac81-4821-95f2-b9fd812a679c.png)