### PR TITLE
Fix a small typo in the artichoke example document

### DIFF
--- a/testdata/example.md
+++ b/testdata/example.md
@@ -7,7 +7,7 @@ A casual introduction. 你好世界!
 
 The _artichoke_ is mentioned as a garden plant in the 8th century BC by Homer
 **and** Hesiod. The naturally occurring variant of the artichoke, the cardoon,
-which is native the the Mediterranean area, also has records of use as a food
+which is native to the Mediterranean area, also has records of use as a food
 among the ancient Greeks and Romans. Pliny the Elder mentioned growing of
 _carduus_ in Carthage and Cordoba.
 


### PR DESCRIPTION
This PR fixes a small typo in the example document that's (mostly) about artichokes.