### PR TITLE
fix: do not replace comments with empty lines

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -156,7 +156,7 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		return Element{
 			Exiting: post,
 			Renderer: &ItemElement{
-				IsOrdered: node.Parent().(*ast.List).IsOrdered(),
+				IsOrdered:   node.Parent().(*ast.List).IsOrdered(),
 				Enumeration: e,
 			},
 		}
@@ -332,7 +332,7 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		n := node.(*ast.HTMLBlock)
 		return Element{
 			Renderer: &BaseElement{
-				Token: ctx.SanitizeHTML(string(n.Text(source)), true) + "\n",
+				Token: ctx.SanitizeHTML(string(n.Text(source)), true),
 				Style: ctx.options.Styles.HTMLBlock.StylePrimitive,
 			},
 		}

--- a/testdata/readme.markdown.in
+++ b/testdata/readme.markdown.in
@@ -23,6 +23,8 @@ Check out the [Gold Style Gallery](https://github.com/charmbracelet/gold/blob/ma
 
 Currently `gold` uses the [Aurora ANSI colors](https://godoc.org/github.com/logrusorgru/aurora#Index).
 
+<!-- comments should be ignored -->
+
 ## Development
 
 Style definitions located in `styles/` can be embedded into the binary by
@@ -31,6 +33,15 @@ running [statik](https://github.com/rakyll/statik):
 ```console
 statik -f -src styles -include "*.json"
 ```
+
+<!--
+multiline comments should also be ignored
+this is one comment with
+more than one
+line
+
+yup
+-->
 
 You can re-generate screenshots of all available styles by running `gallery.sh`.
 This requires `termshot` and `pngcrush` installed on your system!


### PR DESCRIPTION
per my understanding, bluemonday is already removing the comments, but we were appending an empty line to each html block, so each comment was actually being turned into an empty line instead of nothing.

per my tests, seems like we don't need to append that extra line... if we do, we can change it to only add if the contents are not empty.

closes #139