### PR TITLE
fix: register chroma style once

### DIFF
--- a/ansi/codeblock.go
+++ b/ansi/codeblock.go
@@ -2,11 +2,23 @@ package ansi
 
 import (
 	"io"
+	"sync"
 
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/quick"
 	"github.com/alecthomas/chroma/styles"
 	"github.com/muesli/reflow/indent"
+)
+
+const (
+	// The chroma style theme name used for rendering.
+	chromaStyleTheme = "charm"
+)
+
+var (
+	// mutex for synchronizing access to the chroma style registry.
+	// Related https://github.com/alecthomas/chroma/pull/650
+	mutex = sync.Mutex{}
 )
 
 // A CodeBlockElement is used to render code blocks.
@@ -64,41 +76,47 @@ func (e *CodeBlockElement) Render(w io.Writer, ctx RenderContext) error {
 	theme := rules.Theme
 
 	if rules.Chroma != nil && ctx.options.ColorProfile > 1 {
-		theme = "charm"
-		styles.Register(chroma.MustNewStyle("charm",
-			chroma.StyleEntries{
-				chroma.Text:                chromaStyle(rules.Chroma.Text),
-				chroma.Error:               chromaStyle(rules.Chroma.Error),
-				chroma.Comment:             chromaStyle(rules.Chroma.Comment),
-				chroma.CommentPreproc:      chromaStyle(rules.Chroma.CommentPreproc),
-				chroma.Keyword:             chromaStyle(rules.Chroma.Keyword),
-				chroma.KeywordReserved:     chromaStyle(rules.Chroma.KeywordReserved),
-				chroma.KeywordNamespace:    chromaStyle(rules.Chroma.KeywordNamespace),
-				chroma.KeywordType:         chromaStyle(rules.Chroma.KeywordType),
-				chroma.Operator:            chromaStyle(rules.Chroma.Operator),
-				chroma.Punctuation:         chromaStyle(rules.Chroma.Punctuation),
-				chroma.Name:                chromaStyle(rules.Chroma.Name),
-				chroma.NameBuiltin:         chromaStyle(rules.Chroma.NameBuiltin),
-				chroma.NameTag:             chromaStyle(rules.Chroma.NameTag),
-				chroma.NameAttribute:       chromaStyle(rules.Chroma.NameAttribute),
-				chroma.NameClass:           chromaStyle(rules.Chroma.NameClass),
-				chroma.NameConstant:        chromaStyle(rules.Chroma.NameConstant),
-				chroma.NameDecorator:       chromaStyle(rules.Chroma.NameDecorator),
-				chroma.NameException:       chromaStyle(rules.Chroma.NameException),
-				chroma.NameFunction:        chromaStyle(rules.Chroma.NameFunction),
-				chroma.NameOther:           chromaStyle(rules.Chroma.NameOther),
-				chroma.Literal:             chromaStyle(rules.Chroma.Literal),
-				chroma.LiteralNumber:       chromaStyle(rules.Chroma.LiteralNumber),
-				chroma.LiteralDate:         chromaStyle(rules.Chroma.LiteralDate),
-				chroma.LiteralString:       chromaStyle(rules.Chroma.LiteralString),
-				chroma.LiteralStringEscape: chromaStyle(rules.Chroma.LiteralStringEscape),
-				chroma.GenericDeleted:      chromaStyle(rules.Chroma.GenericDeleted),
-				chroma.GenericEmph:         chromaStyle(rules.Chroma.GenericEmph),
-				chroma.GenericInserted:     chromaStyle(rules.Chroma.GenericInserted),
-				chroma.GenericStrong:       chromaStyle(rules.Chroma.GenericStrong),
-				chroma.GenericSubheading:   chromaStyle(rules.Chroma.GenericSubheading),
-				chroma.Background:          chromaStyle(rules.Chroma.Background),
-			}))
+		theme = chromaStyleTheme
+		mutex.Lock()
+		// Don't register the style if it's already registered.
+		_, ok := styles.Registry[theme]
+		if !ok {
+			styles.Register(chroma.MustNewStyle(theme,
+				chroma.StyleEntries{
+					chroma.Text:                chromaStyle(rules.Chroma.Text),
+					chroma.Error:               chromaStyle(rules.Chroma.Error),
+					chroma.Comment:             chromaStyle(rules.Chroma.Comment),
+					chroma.CommentPreproc:      chromaStyle(rules.Chroma.CommentPreproc),
+					chroma.Keyword:             chromaStyle(rules.Chroma.Keyword),
+					chroma.KeywordReserved:     chromaStyle(rules.Chroma.KeywordReserved),
+					chroma.KeywordNamespace:    chromaStyle(rules.Chroma.KeywordNamespace),
+					chroma.KeywordType:         chromaStyle(rules.Chroma.KeywordType),
+					chroma.Operator:            chromaStyle(rules.Chroma.Operator),
+					chroma.Punctuation:         chromaStyle(rules.Chroma.Punctuation),
+					chroma.Name:                chromaStyle(rules.Chroma.Name),
+					chroma.NameBuiltin:         chromaStyle(rules.Chroma.NameBuiltin),
+					chroma.NameTag:             chromaStyle(rules.Chroma.NameTag),
+					chroma.NameAttribute:       chromaStyle(rules.Chroma.NameAttribute),
+					chroma.NameClass:           chromaStyle(rules.Chroma.NameClass),
+					chroma.NameConstant:        chromaStyle(rules.Chroma.NameConstant),
+					chroma.NameDecorator:       chromaStyle(rules.Chroma.NameDecorator),
+					chroma.NameException:       chromaStyle(rules.Chroma.NameException),
+					chroma.NameFunction:        chromaStyle(rules.Chroma.NameFunction),
+					chroma.NameOther:           chromaStyle(rules.Chroma.NameOther),
+					chroma.Literal:             chromaStyle(rules.Chroma.Literal),
+					chroma.LiteralNumber:       chromaStyle(rules.Chroma.LiteralNumber),
+					chroma.LiteralDate:         chromaStyle(rules.Chroma.LiteralDate),
+					chroma.LiteralString:       chromaStyle(rules.Chroma.LiteralString),
+					chroma.LiteralStringEscape: chromaStyle(rules.Chroma.LiteralStringEscape),
+					chroma.GenericDeleted:      chromaStyle(rules.Chroma.GenericDeleted),
+					chroma.GenericEmph:         chromaStyle(rules.Chroma.GenericEmph),
+					chroma.GenericInserted:     chromaStyle(rules.Chroma.GenericInserted),
+					chroma.GenericStrong:       chromaStyle(rules.Chroma.GenericStrong),
+					chroma.GenericSubheading:   chromaStyle(rules.Chroma.GenericSubheading),
+					chroma.Background:          chromaStyle(rules.Chroma.Background),
+				}))
+		}
+		mutex.Unlock()
 	}
 
 	iw := indent.NewWriterPipe(w, indentation+margin, func(wr io.Writer) {


### PR DESCRIPTION
don't register chroma style if it's already registered

this could cause a "concurrent map writes" fatal error when used in a
concurrent setting like a bubbletea wish app