### PR TITLE
feat: Add `pink` theme

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -539,6 +539,117 @@ var (
 		},
 	}
 
+	// PinkStyleConfig is the default pink style.
+	PinkStyleConfig = ansi.StyleConfig{
+		Document: ansi.StyleBlock{
+			Margin: uintPtr(2),
+		},
+		BlockQuote: ansi.StyleBlock{
+			Indent:      uintPtr(1),
+			IndentToken: stringPtr("│ "),
+		},
+		List: ansi.StyleList{
+			LevelIndent: 0,
+		},
+		Heading: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				BlockSuffix: "\n",
+				Color:       stringPtr("212"),
+				Bold:        boolPtr(true),
+			},
+		},
+		H1: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				BlockSuffix: "\n",
+				BlockPrefix: "\n",
+				Prefix:      "",
+			},
+		},
+		H2: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "▌ ",
+			},
+		},
+		H3: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "┃ ",
+			},
+		},
+		H4: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "│ ",
+			},
+		},
+		H5: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "┆ ",
+			},
+		},
+		H6: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "┊ ",
+				Bold:   boolPtr(false),
+			},
+		},
+		Text: ansi.StylePrimitive{},
+		Strikethrough: ansi.StylePrimitive{
+			CrossedOut: boolPtr(true),
+		},
+		Emph: ansi.StylePrimitive{
+			Italic: boolPtr(true),
+		},
+		Strong: ansi.StylePrimitive{
+			Bold: boolPtr(true),
+		},
+		HorizontalRule: ansi.StylePrimitive{
+			Color:  stringPtr("212"),
+			Format: "\n──────\n",
+		},
+		Item: ansi.StylePrimitive{
+			BlockPrefix: "• ",
+		},
+		Enumeration: ansi.StylePrimitive{
+			BlockPrefix: ". ",
+		},
+		Task: ansi.StyleTask{
+			Ticked:   "[✓] ",
+			Unticked: "[ ] ",
+		},
+		Link: ansi.StylePrimitive{
+			Color:     stringPtr("99"),
+			Underline: boolPtr(true),
+		},
+		LinkText: ansi.StylePrimitive{
+			Bold: boolPtr(true),
+		},
+		Image: ansi.StylePrimitive{
+			Underline: boolPtr(true),
+		},
+		ImageText: ansi.StylePrimitive{
+			Format: "Image: {{.text}}",
+		},
+		Code: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:           stringPtr("212"),
+				BackgroundColor: stringPtr("236"),
+				Prefix:          " ",
+				Suffix:          " ",
+			},
+		},
+		Table: ansi.StyleTable{
+			CenterSeparator: stringPtr("┼"),
+			ColumnSeparator: stringPtr("│"),
+			RowSeparator:    stringPtr("─"),
+		},
+		DefinitionList: ansi.StyleBlock{},
+		DefinitionTerm: ansi.StylePrimitive{},
+		DefinitionDescription: ansi.StylePrimitive{
+			BlockPrefix: "\n🠶 ",
+		},
+		HTMLBlock: ansi.StyleBlock{},
+		HTMLSpan:  ansi.StyleBlock{},
+	}
+
 	// NoTTYStyleConfig is the default notty style.
 	NoTTYStyleConfig = ansi.StyleConfig{
 		Document: ansi.StyleBlock{
@@ -651,6 +762,7 @@ var (
 		"ascii":   &ASCIIStyleConfig,
 		"dark":    &DarkStyleConfig,
 		"light":   &LightStyleConfig,
+		"pink":    &PinkStyleConfig,
 		"notty":   &NoTTYStyleConfig,
 		"dracula": &DraculaStyleConfig,
 	}

--- a/styles/pink.json
+++ b/styles/pink.json
@@ -1,0 +1,94 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {},
+  "heading": {
+    "block_suffix": "\n",
+    "color": "212",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "212",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "99",
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "99",
+    "background_color": "0"
+  },
+  "code_block": {
+    "color": "99"
+  },
+  "table": {
+    "center_separator": "┼",
+    "column_separator": "│",
+    "row_separator": "─"
+  },
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}


### PR DESCRIPTION
Adds a `pink`/`purple` duotone theme for glamour.

I think the `code` style is a little less than ideal on light themes because it uses `0` which is very dark as a background.

Preview:

| Dark | Light |
| --- | --- |
| <img width="853" alt="image" src="https://user-images.githubusercontent.com/42545625/179052114-8ca34916-8470-4a7a-8634-7f31d5d3f74b.png"> | <img width="795" alt="image" src="https://user-images.githubusercontent.com/42545625/179052302-0e309cb2-36cd-4c1c-a332-ebe8d8deb785.png"> |

