### PR TITLE
Document default word wrap of 80 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import "github.com/charmbracelet/glamour"
 r, _ := glamour.NewTermRenderer(
     // detect background color and pick either the default dark or light theme
     glamour.WithAutoStyle(),
-    // wrap output at specific width
+    // wrap output at specific width, the default is normally 80
     glamour.WithWordWrap(40),
 )
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import "github.com/charmbracelet/glamour"
 r, _ := glamour.NewTermRenderer(
     // detect background color and pick either the default dark or light theme
     glamour.WithAutoStyle(),
-    // wrap output at specific width, the default is normally 80
+    // wrap output at specific width (default is 80)
     glamour.WithWordWrap(40),
 )
 

--- a/examples/custom_renderer/main.go
+++ b/examples/custom_renderer/main.go
@@ -9,11 +9,7 @@ import (
 func main() {
 	in := `# Custom Renderer
 
-Word-wrapping will occur when lines exceed the limit of 40 characters. Just so
-you know: Glamour's default word-wrapping limit is set to 100 characters per
-line.
-
-Bye!
+Word-wrapping will occur when lines exceed the limit of 40 characters.
 `
 
 	r, _ := glamour.NewTermRenderer(


### PR DESCRIPTION
The default word wrap limit changed from 100 to 80 in commit 71e8425,
but this was un-documented other than a reference to the old 100 limit
in `examples/custom_renderer/main.go`

Remove the reference to the old 100 limit in the example file, and note
the new default of 80 in the readme where it's more likely to be noticed
(and corrected if the default ever changes again in the future).
