### PR TITLE
Indent Adjust Breaking Styles Fix

### DIFF
--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -9,11 +9,11 @@ import (
 func main() {
 	in := `# Hello World
 
-This is a simple example of Markdown rendering with Glamour!
-Check out the [other examples](https://github.com/charmbracelet/glamour/tree/master/examples) too.
+	This is a simple example of Markdown rendering with Glamour!
+	Check out the [other examples](https://github.com/charmbracelet/glamour/tree/master/examples) too.
 
-Bye!
-`
+	Bye!
+	`
 
 	out, _ := glamour.Render(in, "dark")
 	fmt.Print(out)

--- a/glamour.go
+++ b/glamour.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/muesli/termenv"
 	"github.com/yuin/goldmark"
 	emoji "github.com/yuin/goldmark-emoji"
@@ -33,14 +34,16 @@ type TermRenderer struct {
 // Render initializes a new TermRenderer and renders a markdown with a specific
 // style.
 func Render(in string, stylePath string) (string, error) {
-	b, err := RenderBytes([]byte(in), stylePath)
+	indentAdjustedin := heredoc.Doc(in)
+	b, err := RenderBytes([]byte(indentAdjustedin), stylePath)
 	return string(b), err
 }
 
 // RenderWithEnvironmentConfig initializes a new TermRenderer and renders a
 // markdown with a specific style defined by the GLAMOUR_STYLE environment variable.
 func RenderWithEnvironmentConfig(in string) (string, error) {
-	b, err := RenderBytes([]byte(in), getEnvironmentStyle())
+	indentAdjustedin := heredoc.Doc(in)
+	b, err := RenderBytes([]byte(indentAdjustedin), getEnvironmentStyle())
 	return string(b), err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/charmbracelet/glamour
 go 1.13
 
 require (
+	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/alecthomas/chroma v0.10.0
 	github.com/microcosm-cc/bluemonday v1.0.19
 	github.com/muesli/reflow v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZYIR/J6A=
+github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=


### PR DESCRIPTION
# Description

When using proper indented code for multiline strings, the styles rendering for styles, along with other things were breaking.

For example,

```go
func main() {
  in := `# Hello World

  This is a simple example of Markdown rendering with Glamour!
  Check out the [other examples (https://github.com/charmbracelet/glamour/tree/master/examples) too.
	
  Bye!
  `
  out, _ := glamour.Render(in, "dark")
  fmt.Print(out)
}
```

rendered

<img width="534" alt="140563410-5ad2c264-9951-4b89-a425-d38d27b7c505" src="https://user-images.githubusercontent.com/7561070/185780785-074d5393-a0de-4363-8c1b-44b6cd8956eb.png">

instead of 

![helloworld](https://user-images.githubusercontent.com/7561070/185780809-4dc1c667-f432-4056-a242-c557fd918da8.png)

The existing work around was unindent multiline strings, who looks bad and is not the default behavior.

```go
func main() {
    in := `# Hello World

This is a simple example of Markdown rendering with Glamour!
Check out the [other examples (https://github.com/charmbracelet/glamour/tree/master/examples) too.
	
Bye!
`
    out, _ := glamour.Render(in, "dark")
    fmt.Print(out)
}
```
# Related Issue

* #126 

# Screenshots

NA
