### PR TITLE
feature: Option to toggle between Link Text only and Link Text + URL …

### DIFF
--- a/ansi/link.go
+++ b/ansi/link.go
@@ -52,25 +52,29 @@ func (e *LinkElement) Render(w io.Writer, ctx RenderContext) error {
 		}
 	*/
 
-	u, err := url.Parse(e.URL)
-	if err == nil &&
-		"#"+u.Fragment != e.URL { // if the URL only consists of an anchor, ignore it
-		pre := " "
-		style := ctx.options.Styles.Link
-		if !textRendered {
-			pre = ""
-			style.BlockPrefix = ""
-			style.BlockSuffix = ""
-		}
+	// render url if linktext not rendered yet or both should be rendered
+	if !textRendered || !ctx.options.LinkTextOnly {
 
-		el := &BaseElement{
-			Token:  resolveRelativeURL(e.BaseURL, e.URL),
-			Prefix: pre,
-			Style:  style,
-		}
-		err := el.Render(w, ctx)
-		if err != nil {
-			return err
+		u, err := url.Parse(e.URL)
+		if err == nil &&
+			"#"+u.Fragment != e.URL { // if the URL only consists of an anchor, ignore it
+			pre := " "
+			style := ctx.options.Styles.Link
+			if !textRendered {
+				pre = ""
+				style.BlockPrefix = ""
+				style.BlockSuffix = ""
+			}
+
+			el := &BaseElement{
+				Token:  resolveRelativeURL(e.BaseURL, e.URL),
+				Prefix: pre,
+				Style:  style,
+			}
+			err := el.Render(w, ctx)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/ansi/renderer.go
+++ b/ansi/renderer.go
@@ -16,6 +16,7 @@ import (
 // Options is used to configure an ANSIRenderer.
 type Options struct {
 	BaseURL          string
+	LinkTextOnly     bool
 	WordWrap         int
 	PreserveNewLines bool
 	ColorProfile     termenv.Profile

--- a/examples/custom_renderer/main.go
+++ b/examples/custom_renderer/main.go
@@ -10,11 +10,13 @@ func main() {
 	in := `# Custom Renderer
 
 Word-wrapping will occur when lines exceed the limit of 40 characters.
+[Hello World](http://www.google.de)
 `
 
 	r, _ := glamour.NewTermRenderer(
 		glamour.WithStandardStyle("dark"),
 		glamour.WithWordWrap(40),
+		glamour.WithLinkTextOnly(true),
 	)
 
 	out, _ := r.Render(in)

--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -7,14 +7,25 @@ import (
 )
 
 func main() {
-	in := `# Hello World
+	eingang := `# Hello World
 
 This is a simple example of Markdown rendering with Glamour!
 Check out the [other examples](https://github.com/charmbracelet/glamour/tree/master/examples) too.
 
+This is [an example](http://example.com/ "Title") inline link.
+
+[This link](http://example.net/) has no title attribute.
+
+
+This is [an example][id] reference-style link.
+
+
+See my [About](/about/) page for details.
+
+
 Bye!
 `
-
-	out, _ := glamour.Render(in, "dark")
+	out, _ := glamour.Render(eingang, "dark")
+	fmt.Printf("%s", out)
 	fmt.Print(out)
 }

--- a/glamour.go
+++ b/glamour.go
@@ -71,6 +71,7 @@ func NewTermRenderer(options ...TermRendererOption) (*TermRenderer, error) {
 		ansiOptions: ansi.Options{
 			WordWrap:     80,
 			ColorProfile: termenv.TrueColor,
+			LinkTextOnly: false,
 		},
 	}
 	for _, o := range options {
@@ -181,6 +182,13 @@ func WithStylesFromJSONFile(filename string) TermRendererOption {
 func WithWordWrap(wordWrap int) TermRendererOption {
 	return func(tr *TermRenderer) error {
 		tr.ansiOptions.WordWrap = wordWrap
+		return nil
+	}
+}
+
+func WithLinkTextOnly(onlyLinkText bool) TermRendererOption {
+	return func(tr *TermRenderer) error {
+		tr.ansiOptions.LinkTextOnly = onlyLinkText
 		return nil
 	}
 }


### PR DESCRIPTION
Preparing glamour to be configured to render links using the link text only or the Link text and url. 

Ideally in another PR this would be extended to display clickable Link Texts whenever possible. 
When using glow as a quick reader of markdown files, it seems natural to hide the urls, as this is the expected behaviour of a markdown viewer. 