### PR TITLE
Fix link colors

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -200,11 +200,11 @@ var (
 			Unticked:       "[ ] ",
 		},
 		Link: ansi.StylePrimitive{
-			Color:     stringPtr("30"),
+			Color:     stringPtr("123"),
 			Underline: boolPtr(true),
 		},
 		LinkText: ansi.StylePrimitive{
-			Color: stringPtr("35"),
+			Color: stringPtr("123"),
 			Bold:  boolPtr(true),
 		},
 		Image: ansi.StylePrimitive{

--- a/styles/dark.json
+++ b/styles/dark.json
@@ -67,11 +67,11 @@
     "unticked": "[ ] "
   },
   "link": {
-    "color": "30",
+    "color": "123",
     "underline": true
   },
   "link_text": {
-    "color": "35",
+    "color": "123",
     "bold": true
   },
   "image": {


### PR DESCRIPTION
Issues #165 and https://github.com/charmbracelet/glow/issues/455 both mention the bad link styling in h1 headers. @meowgorithm suggested to change the link foreground to `123` which I did here. I made the changes in both `styles.go` and `dark.json`, and the finished output can be seen below. If the problem applies to other color schemes just let me know and I'll apply the changes to those as well :-)

<img width="285" alt="example" src="https://user-images.githubusercontent.com/109045366/215273981-e42edf3a-2361-40ae-8ced-95601b44c12b.png">
