### PR TITLE
Updating `glab` URL in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Check out these projects, which use `glamour`:
 - [Glow](https://github.com/charmbracelet/glow), a markdown renderer for
 the command-line.
 - [GitHub CLI](https://github.com/cli/cli), GitHub’s official command line tool.
-- [GLab](https://github.com/profclems/glab), an open source GitLab command line tool.
+- [GitLab CLI](https://gitlab.com/gitlab-org/cli), GitLab's official command line tool.
 - [Gitea CLI](https://gitea.com/gitea/tea), Gitea's official command line tool.
 - [Meteor](https://github.com/odpf/meteor), an easy-to-use, plugin-driven metadata collection framework.
 


### PR DESCRIPTION
GitLab has adopted `glab` as its official CLI and moved the repo