### PR TITLE
feat: use (exported) consts for default styles

### DIFF
--- a/glamour.go
+++ b/glamour.go
@@ -18,6 +18,17 @@ import (
 	"github.com/charmbracelet/glamour/ansi"
 )
 
+// Default styles.
+const (
+	AsciiStyle   = "ascii"
+	AutoStyle    = "auto"
+	DarkStyle    = "dark"
+	DraculaStyle = "dracula"
+	LightStyle   = "light"
+	NoTTYStyle   = "notty"
+	PinkStyle    = "pink"
+)
+
 // A TermRendererOption sets an option on a TermRenderer.
 type TermRendererOption func(*TermRenderer) error
 
@@ -122,7 +133,7 @@ func WithStandardStyle(style string) TermRendererOption {
 // WithAutoStyle sets a TermRenderer's styles with either the standard dark
 // or light style, depending on the terminal's background color at run-time.
 func WithAutoStyle() TermRendererOption {
-	return WithStandardStyle("auto")
+	return WithStandardStyle(string(AutoStyle))
 }
 
 // WithEnvironmentConfig sets a TermRenderer's styles based on the
@@ -237,14 +248,14 @@ func (tr *TermRenderer) RenderBytes(in []byte) ([]byte, error) {
 func getEnvironmentStyle() string {
 	glamourStyle := os.Getenv("GLAMOUR_STYLE")
 	if len(glamourStyle) == 0 {
-		glamourStyle = "auto"
+		glamourStyle = AutoStyle
 	}
 
 	return glamourStyle
 }
 
 func getDefaultStyle(style string) (*ansi.StyleConfig, error) {
-	if style == "auto" {
+	if style == AutoStyle {
 		if termenv.HasDarkBackground() {
 			return &DarkStyleConfig, nil
 		}

--- a/glamour.go
+++ b/glamour.go
@@ -133,7 +133,7 @@ func WithStandardStyle(style string) TermRendererOption {
 // WithAutoStyle sets a TermRenderer's styles with either the standard dark
 // or light style, depending on the terminal's background color at run-time.
 func WithAutoStyle() TermRendererOption {
-	return WithStandardStyle(string(AutoStyle))
+	return WithStandardStyle(AutoStyle)
 }
 
 // WithEnvironmentConfig sets a TermRenderer's styles based on the

--- a/glamour_test.go
+++ b/glamour_test.go
@@ -15,7 +15,7 @@ const (
 
 func TestTermRendererWriter(t *testing.T) {
 	r, err := NewTermRenderer(
-		WithStandardStyle("dark"),
+		WithStandardStyle(DarkStyle),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -152,7 +152,7 @@ func TestStyles(t *testing.T) {
 	}
 
 	_, err = NewTermRenderer(
-		WithStandardStyle("auto"),
+		WithStandardStyle(AutoStyle),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/styles.go
+++ b/styles.go
@@ -759,12 +759,12 @@ var (
 
 	// DefaultStyles are the default styles.
 	DefaultStyles = map[string]*ansi.StyleConfig{
-		"ascii":   &ASCIIStyleConfig,
-		"dark":    &DarkStyleConfig,
-		"light":   &LightStyleConfig,
-		"pink":    &PinkStyleConfig,
-		"notty":   &NoTTYStyleConfig,
-		"dracula": &DraculaStyleConfig,
+		AsciiStyle:   &ASCIIStyleConfig,
+		DarkStyle:    &DarkStyleConfig,
+		DraculaStyle: &DraculaStyleConfig,
+		LightStyle:   &LightStyleConfig,
+		NoTTYStyle:   &NoTTYStyleConfig,
+		PinkStyle:    &PinkStyleConfig,
 	}
 )
 

--- a/testdata/fuzz/fuzz.go
+++ b/testdata/fuzz/fuzz.go
@@ -3,7 +3,7 @@ package fuzzing
 import "github.com/charmbracelet/glamour"
 
 func Fuzz(data []byte) int {
-	_, err := glamour.RenderBytes(data, "dark")
+	_, err := glamour.RenderBytes(data, glamour.Dark)
 	if err != nil {
 		return 0
 	}

--- a/testdata/fuzz/fuzz.go
+++ b/testdata/fuzz/fuzz.go
@@ -3,7 +3,7 @@ package fuzzing
 import "github.com/charmbracelet/glamour"
 
 func Fuzz(data []byte) int {
-	_, err := glamour.RenderBytes(data, glamour.Dark)
+	_, err := glamour.RenderBytes(data, glamour.DarkStyle)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
While building an application with Glamour rendering, the linter suggested adding constants when `"auto"` appeared in several places in the codebase. To that end, this PR introduces string constants that can be used to reference the default styles.

* `AsciiStyle`
* `AutoStyle`
* `DarkStyle`
* `DraculaStyle`
* `LightStyle`
* `NoTTYStyle`
* `PinkStyle`

Note that this revision uses the constants internally as well, however I have left the examples in the README as-is for sake of simplicity.