### PR TITLE
Render URLs in table

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -306,8 +306,13 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		s := ""
 		n := node.FirstChild()
 		for n != nil {
-			s += string(n.Text(source))
-			// s += string(n.LinkData.Destination)
+			switch t := n.(type) {
+			case *ast.AutoLink:
+				s += string(t.Label(source))
+			default:
+				s += string(n.Text(source))
+			}
+
 			n = n.NextSibling()
 		}
 

--- a/styles/examples/table.md
+++ b/styles/examples/table.md
@@ -1,4 +1,4 @@
-| Label  | Value |
-| ------ | ----- |
-| First  | foo   |
-| Second | bar   |
+| Label  | Value | URL              |
+| ------ | ----- | ---------------- |
+| First  | foo   | https://charm.sh |
+| Second | bar   | https://charm.sh |

--- a/testdata/table.test
+++ b/testdata/table.test
@@ -1,5 +1,5 @@
                                                                                 
-      LABEL  | VALUE                                                            
-    ---------+--------                                                          
-      First  | foo                                                              
-      Second | bar                                                              
+      LABEL  | VALUE |       URL                                                
+    ---------+-------+-------------------                                       
+      First  | foo   | https://charm.sh                                         
+      Second | bar   | https://charm.sh                                         


### PR DESCRIPTION
The `Text()` function does not work for the `AutoLink` struct.

Closes https://github.com/charmbracelet/glow/issues/525