### PR TITLE
Workaround for Chroma detecting line feed as error

### DIFF
--- a/styles/dark.json
+++ b/styles/dark.json
@@ -96,8 +96,7 @@
         "color": "#C4C4C4"
       },
       "error": {
-        "color": "#F1F1F1",
-        "background_color": "#F05B5B"
+        "color": "#F05B5B"
       },
       "comment": {
         "color": "#676767"

--- a/styles/dracula.json
+++ b/styles/dracula.json
@@ -91,8 +91,7 @@
         "color": "#f8f8f2"
       },
       "error": {
-        "color": "#f8f8f2",
-        "background_color": "#ff5555"
+        "color": "#ff5555"
       },
       "comment": {
         "color": "#6272A4"

--- a/styles/light.json
+++ b/styles/light.json
@@ -95,8 +95,7 @@
         "color": "#2A2A2A"
       },
       "error": {
-        "color": "#F1F1F1",
-        "background_color": "#FF5555"
+        "color": "#FF5555"
       },
       "comment": {
         "color": "#8D8D8D"


### PR DESCRIPTION
Glamour renders \n as visible error when rendering VimL code blocks. This is due to lexer bug in Chroma, now fixed, but yet to be released, combined with the code block error style in Glamour rendering errors with a red background (rather than Chroma default of using red text).

See https://github.com/alecthomas/chroma/issues/827 for more info

Updating Glamour styles to use red text rather than a red background works around this, because there is no printable text to highlight.

Note that for dracula, the style for generic deleted and error are now the same, but this seems a reasonable compromise as generic deleted is primarily for diffs, which seem less likely to result in lexer errors.

Although this might seem like a fugly hack to address one specific issue, it seems a pretty reasonable default to me as Glamour has no control over Chroma's parsing of code blocks, only the highlighting, and barring a new release of Glamour with updated dependencies, cannot do anything about Chroma lexer errors other than highlight them.