### PR TITLE
Add option to disable auto email `mailto:` links

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -227,6 +227,13 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		u := string(n.URL(source))
 		label := string(n.Label(source))
 		if n.AutoLinkType == ast.AutoLinkEmail && !strings.HasPrefix(strings.ToLower(u), "mailto:") {
+			if tr.context.options.DisableAutoEmailLinks {
+				return Element{
+					Renderer: &BaseElement{
+						Token: label,
+					},
+				}
+			}
 			u = "mailto:" + u
 		}
 

--- a/ansi/renderer.go
+++ b/ansi/renderer.go
@@ -15,11 +15,12 @@ import (
 
 // Options is used to configure an ANSIRenderer.
 type Options struct {
-	BaseURL          string
-	WordWrap         int
-	PreserveNewLines bool
-	ColorProfile     termenv.Profile
-	Styles           StyleConfig
+	BaseURL               string
+	WordWrap              int
+	PreserveNewLines      bool
+	DisableAutoEmailLinks bool
+	ColorProfile          termenv.Profile
+	Styles                StyleConfig
 }
 
 // ANSIRenderer renders markdown content as ANSI escaped sequences.

--- a/glamour.go
+++ b/glamour.go
@@ -212,6 +212,14 @@ func WithEmoji() TermRendererOption {
 	}
 }
 
+// WithDisabledMailtoLinks sets TermRenderer's option to disable adding mailto links.
+func WithDisableAutoEmailLinks(v bool) TermRendererOption {
+	return func(tr *TermRenderer) error {
+		tr.ansiOptions.DisableAutoEmailLinks = v
+		return nil
+	}
+}
+
 func (tr *TermRenderer) Read(b []byte) (int, error) {
 	return tr.renderBuf.Read(b)
 }

--- a/glamour_test.go
+++ b/glamour_test.go
@@ -113,6 +113,27 @@ func TestWithEmoji(t *testing.T) {
 	}
 }
 
+func TestDisableAutoEmailLinks(t *testing.T) {
+	r, err := NewTermRenderer(
+		WithDisableAutoEmailLinks(true),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	goModuleExample := "This is my favorite go module: golang.org/x/net@v0.0.1"
+
+	b, err := r.Render(goModuleExample)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b = strings.TrimSpace(b)
+
+	if b != goModuleExample {
+		t.Errorf("Rendered output doesn't match!\nExpected: `\n%s`\nGot: `\n%s`\n", goModuleExample, b)
+	}
+}
+
 func TestWithPreservedNewLines(t *testing.T) {
 	r, err := NewTermRenderer(
 		WithPreservedNewLines(),


### PR DESCRIPTION
This PR aims to fix #260 #82 by adding an option to disable auto email `mailto:` links.