### PR TITLE
Replaced deprecated io/ioutil package with proper implementations of …

### DIFF
--- a/ansi/renderer_test.go
+++ b/ansi/renderer_test.go
@@ -3,8 +3,8 @@ package ansi
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"path/filepath"
+	"os"
 	"strings"
 	"testing"
 
@@ -35,11 +35,11 @@ func TestRenderer(t *testing.T) {
 		sn := filepath.Join(examplesDir, bn+".style")
 		tn := filepath.Join("../testdata", bn+".test")
 
-		in, err := ioutil.ReadFile(f)
+		in, err := os.ReadFile(f)
 		if err != nil {
 			t.Fatal(err)
 		}
-		b, err := ioutil.ReadFile(sn)
+		b, err := os.ReadFile(sn)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -77,7 +77,7 @@ func TestRenderer(t *testing.T) {
 
 		// generate
 		if generateExamples {
-			err = ioutil.WriteFile(tn, buf.Bytes(), 0644)
+			err = os.WriteFile(tn, buf.Bytes(), 0644)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -85,7 +85,7 @@ func TestRenderer(t *testing.T) {
 		}
 
 		// verify
-		td, err := ioutil.ReadFile(tn)
+		td, err := os.ReadFile(tn)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -108,11 +108,11 @@ func TestRendererIssues(t *testing.T) {
 		t.Run(bn, func(t *testing.T) {
 			tn := filepath.Join(issuesDir, bn+".test")
 
-			in, err := ioutil.ReadFile(f)
+			in, err := os.ReadFile(f)
 			if err != nil {
 				t.Fatal(err)
 			}
-			b, err := ioutil.ReadFile("../styles/dark.json")
+			b, err := os.ReadFile("../styles/dark.json")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -150,7 +150,7 @@ func TestRendererIssues(t *testing.T) {
 
 			// generate
 			if generateIssues {
-				err = ioutil.WriteFile(tn, buf.Bytes(), 0644)
+				err = os.WriteFile(tn, buf.Bytes(), 0644)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -158,7 +158,7 @@ func TestRendererIssues(t *testing.T) {
 			}
 
 			// verify
-			td, err := ioutil.ReadFile(tn)
+			td, err := os.ReadFile(tn)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/glamour_test.go
+++ b/glamour_test.go
@@ -2,7 +2,8 @@ package glamour
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
+	"os"
 	"strings"
 	"testing"
 )
@@ -21,7 +22,7 @@ func TestTermRendererWriter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	in, err := ioutil.ReadFile(markdown)
+	in, err := os.ReadFile(markdown)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,14 +36,14 @@ func TestTermRendererWriter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// generate
 	if generate {
-		err := ioutil.WriteFile(testFile, b, 0644)
+		err := os.WriteFile(testFile, b, 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -50,7 +51,7 @@ func TestTermRendererWriter(t *testing.T) {
 	}
 
 	// verify
-	td, err := ioutil.ReadFile(testFile)
+	td, err := os.ReadFile(testFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +70,7 @@ func TestTermRenderer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	in, err := ioutil.ReadFile(markdown)
+	in, err := os.ReadFile(markdown)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +81,7 @@ func TestTermRenderer(t *testing.T) {
 	}
 
 	// verify
-	td, err := ioutil.ReadFile(testFile)
+	td, err := os.ReadFile(testFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +122,7 @@ func TestWithPreservedNewLines(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	in, err := ioutil.ReadFile("testdata/preserved_newline.in")
+	in, err := os.ReadFile("testdata/preserved_newline.in")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +133,7 @@ func TestWithPreservedNewLines(t *testing.T) {
 	}
 
 	// verify
-	td, err := ioutil.ReadFile("testdata/preserved_newline.test")
+	td, err := os.ReadFile("testdata/preserved_newline.test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +168,7 @@ func TestStyles(t *testing.T) {
 }
 
 func TestRenderHelpers(t *testing.T) {
-	in, err := ioutil.ReadFile(markdown)
+	in, err := os.ReadFile(markdown)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +179,7 @@ func TestRenderHelpers(t *testing.T) {
 	}
 
 	// verify
-	td, err := ioutil.ReadFile(testFile)
+	td, err := os.ReadFile(testFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +210,7 @@ func TestCapitalization(t *testing.T) {
 	}
 
 	// expected outcome
-	td, err := ioutil.ReadFile("testdata/capitalization.test")
+	td, err := os.ReadFile("testdata/capitalization.test")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
…io/os packages.

As of Go v1.16, the io/ioutil package has been deprecated and replaced with io and os implementations. https://go.dev/doc/go1.16#ioutil