### PR TITLE
Use specified indent token with codeblock

### DIFF
--- a/ansi/codeblock.go
+++ b/ansi/codeblock.go
@@ -118,8 +118,12 @@ func (e *CodeBlockElement) Render(w io.Writer, ctx RenderContext) error {
 		mutex.Unlock()
 	}
 
+	ic := " "
+	if rules.IndentToken != nil {
+		ic = *rules.IndentToken
+	}
 	iw := indent.NewWriterPipe(w, indentation+margin, func(wr io.Writer) {
-		renderText(w, ctx.options.ColorProfile, bs.Current().Style.StylePrimitive, " ")
+		renderText(w, ctx.options.ColorProfile, bs.Current().Style.StylePrimitive, ic)
 	})
 
 	if len(theme) > 0 {


### PR DESCRIPTION
Specifying an indent token in the code block style currently has no impact. This change incorporates the specified token when rendering code blocks.