### PR TITLE
fix: broken margin rendering

### DIFF
--- a/ansi/blockstack.go
+++ b/ansi/blockstack.go
@@ -59,10 +59,10 @@ func (s BlockStack) Margin() uint {
 
 // Width returns the available rendering width.
 func (s BlockStack) Width(ctx RenderContext) uint {
-	if s.Indent()*s.Margin() > uint(ctx.options.WordWrap) {
+	if s.Indent()+s.Margin()*2 > uint(ctx.options.WordWrap) {
 		return 0
 	}
-	return uint(ctx.options.WordWrap) - s.Indent()*s.Margin()
+	return uint(ctx.options.WordWrap) - s.Indent() - s.Margin()*2
 }
 
 // Parent returns the current BlockElement's parent.


### PR DESCRIPTION
The margin and indent are both absolute values and should not be multiplied with one another. This commit partially reverts 5f5965e which introduced the bug.

Fixes: charmbracelet/glamour#331