### PR TITLE
fix(table): fix rendering table in ascii-only mode

### DIFF
--- a/styles/styles.go
+++ b/styles/styles.go
@@ -122,7 +122,11 @@ var (
 				Margin: uintPtr(defaultMargin),
 			},
 		},
-		Table: ansi.StyleTable{},
+		Table: ansi.StyleTable{
+			CenterSeparator: stringPtr("|"),
+			ColumnSeparator: stringPtr("|"),
+			RowSeparator:    stringPtr("-"),
+		},
 		DefinitionDescription: ansi.StylePrimitive{
 			BlockPrefix: "\n* ",
 		},


### PR DESCRIPTION
Closes https://github.com/charmbracelet/glamour/issues/383

Using `styles.ASCIIStyleConfig` should make _all characters_ be ASCII, but the table configuration was forgotten.