### PR TITLE
(v2) refactor: remove auto style and make dark the default

### DIFF
--- a/glamour.go
+++ b/glamour.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/charmbracelet/glamour/v2/ansi"
 	styles "github.com/charmbracelet/glamour/v2/styles"
-	"github.com/charmbracelet/lipgloss/v2"
-	"github.com/charmbracelet/x/term"
 )
 
 const (
@@ -114,12 +112,6 @@ func WithStandardStyle(style string) TermRendererOption {
 		tr.ansiOptions.Styles = *styles
 		return nil
 	}
-}
-
-// WithAutoStyle sets a TermRenderer's styles with either the standard dark
-// or light style, depending on the terminal's background color at run-time.
-func WithAutoStyle() TermRendererOption {
-	return WithStandardStyle(styles.AutoStyle)
 }
 
 // WithEnvironmentConfig sets a TermRenderer's styles based on the
@@ -275,28 +267,13 @@ func (tr *TermRenderer) RenderBytes(in []byte) ([]byte, error) {
 func getEnvironmentStyle() string {
 	glamourStyle := os.Getenv("GLAMOUR_STYLE")
 	if len(glamourStyle) == 0 {
-		glamourStyle = styles.AutoStyle
+		glamourStyle = styles.DarkStyle
 	}
 
 	return glamourStyle
 }
 
-var (
-	isatty    = term.IsTerminal(os.Stdout.Fd())
-	hasDarkBg = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
-)
-
 func getDefaultStyle(style string) (*ansi.StyleConfig, error) {
-	if style == styles.AutoStyle {
-		if !isatty {
-			return &styles.NoTTYStyleConfig, nil
-		}
-		if hasDarkBg {
-			return &styles.DarkStyleConfig, nil
-		}
-		return &styles.LightStyleConfig, nil
-	}
-
 	styles, ok := styles.DefaultStyles[style]
 	if !ok {
 		return nil, fmt.Errorf("%s: style not found", style)

--- a/glamour_test.go
+++ b/glamour_test.go
@@ -111,15 +111,13 @@ func TestWithPreservedNewLines(t *testing.T) {
 }
 
 func TestStyles(t *testing.T) {
-	_, err := NewTermRenderer(
-		WithAutoStyle(),
-	)
+	_, err := NewTermRenderer()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	_, err = NewTermRenderer(
-		WithStandardStyle(styles.AutoStyle),
+		WithStandardStyle(styles.DarkStyle),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -144,8 +142,8 @@ func TestCustomStyle(t *testing.T) {
 		expected  string
 	}{
 		{name: "style exists", stylePath: "testdata/custom.style", err: nil, expected: "testdata/custom.style"},
-		{name: "style doesn't exist", stylePath: "testdata/notfound.style", err: os.ErrNotExist, expected: styles.AutoStyle},
-		{name: "style is empty", stylePath: "", err: nil, expected: styles.AutoStyle},
+		{name: "style doesn't exist", stylePath: "testdata/notfound.style", err: os.ErrNotExist, expected: styles.DarkStyle},
+		{name: "style is empty", stylePath: "", err: nil, expected: styles.DarkStyle},
 	}
 
 	for _, tc := range tests {

--- a/styles/styles.go
+++ b/styles/styles.go
@@ -15,7 +15,6 @@ const (
 // Default styles.
 const (
 	AsciiStyle      = "ascii" //nolint: revive
-	AutoStyle       = "auto"
 	DarkStyle       = "dark"
 	DraculaStyle    = "dracula"
 	TokyoNightStyle = "tokyo-night"


### PR DESCRIPTION
This purify the Glamour API by removing the auto style feature and making the dark style the default. Glamour no longer needs to query the terminal background to determine the style to use. Querying the terminal is now part of Lip Gloss v2.