### PR TITLE
fix: add conceal property in elements/text rendering

### DIFF
--- a/ansi/baseelement.go
+++ b/ansi/baseelement.go
@@ -40,6 +40,10 @@ func renderText(w io.Writer, p termenv.Profile, rules StylePrimitive, s string) 
 		return
 	}
 
+	if rules.Conceal != nil && *rules.Conceal {
+		return
+	}
+
 	out := termenv.String(s)
 	if rules.Upper != nil && *rules.Upper {
 		out = termenv.String(cases.Upper(language.English).String(s))


### PR DESCRIPTION
## Description

This PR fixes the conceal style in renderText, which wasn't working before. Although Conceal was defined in StylePrimitive, it wasn't being used during rendering.

Closes: [Using a custom style with conceal:true does not hide element #645](https://github.com/charmbracelet/glow/issues/645)

## Changes

- renderText now checks the Conceal property
- if `"conceal"` is true, the text is skipped during rendering

## Testing

Tested with a minimal custom style that uses the conceal property for the elements:

```json
{
  "document": {
    "block_prefix": "\n",
    "block_suffix": "\n",
    "color": "#d0d0d0",
    "margin": 0
  },
  "paragraph": {},
  "heading": {
    "color": "#87d7ff",
    "bold": true
  },
  "link": {
    "color": "#00afd7",
    "underline": true,
    "conceal": true
  },
  "link_text": {
    "color": "#00afd7",
    "underline": true
  },
  "code": {
    "color": "#d7d7ae",
    "conceal": true
  },
  "image": {
    "color": "#00afd7",
    "conceal": true
  },
  "image_text": {
    "color": "#00afd7",
    "underline": true
  }
}
```

```md
# Concealment Test

## Links

This is a [test link](https://example.com) that should conceal the URL.

## Code

Some `inline code` that we might want to conceal.

## Images

![Image alt text](https://example.com/image.jpg)
```