### PR TITLE
feat(tables): format github links inside tables in a more readable manner

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/charmbracelet/glamour/internal/autolink"
 	east "github.com/yuin/goldmark-emoji/ast"
 	"github.com/yuin/goldmark/ast"
 	astext "github.com/yuin/goldmark/extension/ast"
@@ -278,6 +279,9 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 				content:  domain,
 				href:     u,
 				linkType: linkTypeAuto,
+			}
+			if shortned, ok := autolink.Detect(u); ok {
+				tl.content = shortned
 			}
 			text := linkWithSuffix(tl, ctx.table.tableLinks)
 

--- a/ansi/table_links.go
+++ b/ansi/table_links.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/charmbracelet/glamour/internal/autolink"
 	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/exp/slice"
 	"github.com/yuin/goldmark/ast"
@@ -134,6 +135,9 @@ func (e *TableElement) collectLinksAndImages(ctx RenderContext) error {
 				href:     uri,
 				content:  linkDomain(uri),
 				linkType: linkTypeAuto,
+			}
+			if shortned, ok := autolink.Detect(uri); ok {
+				autoLink.content = shortned
 			}
 			links = append(links, autoLink)
 		case *ast.Image:

--- a/ansi/testdata/TestRenderer/table_with_footer_auto_links_short.golden
+++ b/ansi/testdata/TestRenderer/table_with_footer_auto_links_short.golden
@@ -1,0 +1,44 @@
+                                                                                
+ Description                           │ Link                                   
+───────────────────────────────────────┼──────────────────────────────────────  
+ Issue                                 │ [38;5;35;1mowner/repo#123[1][0m                      
+ Issue                                 │ [38;5;35;1mowner/repo#123[2][0m                      
+ Issue Comment                         │ [38;5;35;1mowner/repo#123 (comment)[3][0m            
+ Issue Comment                         │ [38;5;35;1mowner/repo#123 (comment)[4][0m            
+ Pull Request                          │ [38;5;35;1mowner/repo#123[5][0m                      
+ Pull Request                          │ [38;5;35;1mowner/repo#123[6][0m                      
+ Pull Request Comment                  │ [38;5;35;1mowner/repo#123 (comment)[7][0m            
+ Pull Request Comment                  │ [38;5;35;1mowner/repo#123 (comment)[8][0m            
+ Pull Request Comment                  │ [38;5;35;1mowner/repo#123 (comment)[9][0m            
+ Pull Request Comment                  │ [38;5;35;1mowner/repo#123 (comment)[10][0m           
+ Pull Request Review                   │ [38;5;35;1mowner/repo#123 (review)[11][0m            
+ Pull Request Review                   │ [38;5;35;1mowner/repo#123 (review)[12][0m            
+ Discussion                            │ [38;5;35;1mowner/repo#123[13][0m                     
+ Discussion Comment                    │ [38;5;35;1mowner/repo#123 (comment)[14][0m           
+ Commit                                │ [38;5;35;1mowner/repo@abcdefg[15][0m                 
+ Commit                                │ [38;5;35;1mowner/repo@abcdefg[16][0m                 
+ Pull Request Commit                   │ [38;5;35;1mowner/repo@abcdefg[17][0m                 
+ Pull Request Commit                   │ [38;5;35;1mowner/repo@abcdefg[18][0m                 
+ Pull Request Commit                   │ [38;5;35;1mowner/repo@abcdefg[19][0m                 
+ Pull Request Commit                   │ [38;5;35;1mowner/repo@abcdefg[20][0m                 
+                                                                                
+[38;5;35;1m[0m[38;5;35;1m [1]: owner/repo#123[0m [38;5;30;4mhttps://github.com/owner/repo/issue/123[0m                    
+[38;5;35;1m[0m[38;5;35;1m [2]: owner/repo#123[0m [38;5;30;4mhttps://github.com/owner/repo/issues/123[0m                   
+[38;5;35;1m[0m[38;5;35;1m [3]: owner/repo#123 (comment)[0m [38;5;30;4mhttps://github.com/owner/repo/issue/123#issuecom…[0m
+[38;5;35;1m[0m[38;5;35;1m [4]: owner/repo#123 (comment)[0m [38;5;30;4mhttps://github.com/owner/repo/issues/123#issueco…[0m
+[38;5;35;1m[0m[38;5;35;1m [5]: owner/repo#123[0m [38;5;30;4mhttps://github.com/owner/repo/pull/123[0m                     
+[38;5;35;1m[0m[38;5;35;1m [6]: owner/repo#123[0m [38;5;30;4mhttps://github.com/owner/repo/pulls/123[0m                    
+[38;5;35;1m[0m[38;5;35;1m [7]: owner/repo#123 (comment)[0m [38;5;30;4mhttps://github.com/owner/repo/pull/123#issuecomm…[0m
+[38;5;35;1m[0m[38;5;35;1m [8]: owner/repo#123 (comment)[0m [38;5;30;4mhttps://github.com/owner/repo/pulls/123#issuecom…[0m
+[38;5;35;1m[0m[38;5;35;1m [9]: owner/repo#123 (comment)[0m [38;5;30;4mhttps://github.com/owner/repo/pull/123#discussio…[0m
+[38;5;35;1m[0m[38;5;35;1m[10]: owner/repo#123 (comment)[0m [38;5;30;4mhttps://github.com/owner/repo/pulls/123#discussi…[0m
+[38;5;35;1m[0m[38;5;35;1m[11]: owner/repo#123 (review)[0m [38;5;30;4mhttps://github.com/owner/repo/pull/123#pullreques…[0m
+[38;5;35;1m[0m[38;5;35;1m[12]: owner/repo#123 (review)[0m [38;5;30;4mhttps://github.com/owner/repo/pulls/123#pullreque…[0m
+[38;5;35;1m[0m[38;5;35;1m[13]: owner/repo#123[0m [38;5;30;4mhttps://github.com/owner/repo/discussions/123[0m              
+[38;5;35;1m[0m[38;5;35;1m[14]: owner/repo#123 (comment)[0m [38;5;30;4mhttps://github.com/owner/repo/discussions/123#di…[0m
+[38;5;35;1m[0m[38;5;35;1m[15]: owner/repo@abcdefg[0m [38;5;30;4mhttps://github.com/owner/repo/commit/abcdefghijklmnopq…[0m
+[38;5;35;1m[0m[38;5;35;1m[16]: owner/repo@abcdefg[0m [38;5;30;4mhttps://github.com/owner/repo/commit/abcdefghijklmnopq…[0m
+[38;5;35;1m[0m[38;5;35;1m[17]: owner/repo@abcdefg[0m [38;5;30;4mhttps://github.com/owner/repo/pull/123/commits/abcdefg…[0m
+[38;5;35;1m[0m[38;5;35;1m[18]: owner/repo@abcdefg[0m [38;5;30;4mhttps://github.com/owner/repo/pulls/123/commits/abcdef…[0m
+[38;5;35;1m[0m[38;5;35;1m[19]: owner/repo@abcdefg[0m [38;5;30;4mhttps://github.com/owner/repo/pull/123/commits/abcdefg…[0m
+[38;5;35;1m[0m[38;5;35;1m[20]: owner/repo@abcdefg[0m [38;5;30;4mhttps://github.com/owner/repo/pulls/123/commits/abcdef…[0m

--- a/internal/autolink/autolink.go
+++ b/internal/autolink/autolink.go
@@ -1,0 +1,55 @@
+// Package autolink provides a function to detect and format GitHub links into
+// a more readable manner.
+package autolink
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type pattern struct {
+	pattern *regexp.Regexp
+	yield   func(m []string) string
+}
+
+var patterns = []pattern{
+	{
+		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/(issues?|pulls?|discussions?)/([0-9]+)$`),
+		func(m []string) string { return fmt.Sprintf("%s/%s#%s", m[1], m[2], m[4]) },
+	},
+	{
+		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/(issues?|pulls?|discussions?)/([0-9]+)#issuecomment-[0-9]+$`),
+		func(m []string) string { return fmt.Sprintf("%s/%s#%s (comment)", m[1], m[2], m[4]) },
+	},
+	{
+		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/pulls?/([0-9]+)#discussion_r[0-9]+$`),
+		func(m []string) string { return fmt.Sprintf("%s/%s#%s (comment)", m[1], m[2], m[3]) },
+	},
+	{
+		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/pulls?/([0-9]+)#pullrequestreview-[0-9]+$`),
+		func(m []string) string { return fmt.Sprintf("%s/%s#%s (review)", m[1], m[2], m[3]) },
+	},
+	{
+		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/discussions/([0-9]+)#discussioncomment-[0-9]+$`),
+		func(m []string) string { return fmt.Sprintf("%s/%s#%s (comment)", m[1], m[2], m[3]) },
+	},
+	{
+		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/commit/([A-z0-9]{7,})(#.*)?$`),
+		func(m []string) string { return fmt.Sprintf("%s/%s@%s", m[1], m[2], m[3][:7]) },
+	},
+	{
+		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/pulls?/[0-9]+/commits/([A-z0-9]{7,})(#.*)?$`),
+		func(m []string) string { return fmt.Sprintf("%s/%s@%s", m[1], m[2], m[3][:7]) },
+	},
+}
+
+// Detect checks if the given URL matches any of the known patterns and
+// returns a human-readable formatted string if a match is found.
+func Detect(u string) (string, bool) {
+	for _, p := range patterns {
+		if m := p.pattern.FindStringSubmatch(u); len(m) > 0 {
+			return p.yield(m), true
+		}
+	}
+	return "", false
+}

--- a/internal/autolink/autolink_test.go
+++ b/internal/autolink/autolink_test.go
@@ -1,0 +1,53 @@
+package autolink_test
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/glamour/internal/autolink"
+)
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		url      string
+		expected string
+	}{
+		{"https://github.com/owner/repo/issue/123", "owner/repo#123"},
+		{"https://github.com/owner/repo/issues/123", "owner/repo#123"},
+		{"https://github.com/owner/repo/pull/123", "owner/repo#123"},
+		{"https://github.com/owner/repo/pulls/123", "owner/repo#123"},
+		{"https://github.com/owner/repo/discussions/123", "owner/repo#123"},
+
+		{"https://github.com/owner/repo/issue/123#issuecomment-456", "owner/repo#123 (comment)"},
+		{"https://github.com/owner/repo/issues/123#issuecomment-456", "owner/repo#123 (comment)"},
+		{"https://github.com/owner/repo/pull/123#issuecomment-456", "owner/repo#123 (comment)"},
+		{"https://github.com/owner/repo/pulls/123#issuecomment-456", "owner/repo#123 (comment)"},
+
+		{"https://github.com/owner/repo/pull/123#discussion_r456", "owner/repo#123 (comment)"},
+		{"https://github.com/owner/repo/pulls/123#discussion_r456", "owner/repo#123 (comment)"},
+
+		{"https://github.com/owner/repo/pull/123#pullrequestreview-456", "owner/repo#123 (review)"},
+		{"https://github.com/owner/repo/pulls/123#pullrequestreview-456", "owner/repo#123 (review)"},
+
+		{"https://github.com/owner/repo/discussions/123#discussioncomment-456", "owner/repo#123 (comment)"},
+
+		{"https://github.com/owner/repo/commit/abcdefghijklmnopqrsxyz", "owner/repo@abcdefg"},
+
+		{"https://github.com/owner/repo/pull/123/commits/abcdefghijklmnopqrsxyz", "owner/repo@abcdefg"},
+		{"https://github.com/owner/repo/pulls/123/commits/abcdefghijklmnopqrsxyz", "owner/repo@abcdefg"},
+
+		{"https://github.com/owner/repo/commit/abcdefghijklmnopqrsxyz#diff-123", "owner/repo@abcdefg"},
+		{"https://github.com/owner/repo/pull/123/commits/abcdefghijklmnopqrsxyz#diff-123", "owner/repo@abcdefg"},
+		{"https://github.com/owner/repo/pulls/123/commits/abcdefghijklmnopqrsxyz#diff-123", "owner/repo@abcdefg"},
+	}
+	for _, test := range tests {
+		t.Run(test.url, func(t *testing.T) {
+			result, ok := autolink.Detect(test.url)
+			if !ok {
+				t.Errorf("expected to detect URL, got nil")
+			}
+			if result != test.expected {
+				t.Errorf("expected %s, got %s", test.expected, result)
+			}
+		})
+	}
+}

--- a/styles/examples/table_with_footer_auto_links_short.md
+++ b/styles/examples/table_with_footer_auto_links_short.md
@@ -1,0 +1,22 @@
+| Description          | Link                                                                            |
+| -------------------- | ------------------------------------------------------------------------------- |
+| Issue                | https://github.com/owner/repo/issue/123                                         |
+| Issue                | https://github.com/owner/repo/issues/123                                        |
+| Issue Comment        | https://github.com/owner/repo/issue/123#issuecomment-456                        |
+| Issue Comment        | https://github.com/owner/repo/issues/123#issuecomment-456                       |
+| Pull Request         | https://github.com/owner/repo/pull/123                                          |
+| Pull Request         | https://github.com/owner/repo/pulls/123                                         |
+| Pull Request Comment | https://github.com/owner/repo/pull/123#issuecomment-456                         |
+| Pull Request Comment | https://github.com/owner/repo/pulls/123#issuecomment-456                        |
+| Pull Request Comment | https://github.com/owner/repo/pull/123#discussion_r456                          |
+| Pull Request Comment | https://github.com/owner/repo/pulls/123#discussion_r456                         |
+| Pull Request Review  | https://github.com/owner/repo/pull/123#pullrequestreview-456                    |
+| Pull Request Review  | https://github.com/owner/repo/pulls/123#pullrequestreview-456                   |
+| Discussion           | https://github.com/owner/repo/discussions/123                                   |
+| Discussion Comment   | https://github.com/owner/repo/discussions/123#discussioncomment-456             |
+| Commit               | https://github.com/owner/repo/commit/abcdefghijklmnopqrsxyz                     |
+| Commit               | https://github.com/owner/repo/commit/abcdefghijklmnopqrsxyz#diff-123            |
+| Pull Request Commit  | https://github.com/owner/repo/pull/123/commits/abcdefghijklmnopqrsxyz           |
+| Pull Request Commit  | https://github.com/owner/repo/pulls/123/commits/abcdefghijklmnopqrsxyz          |
+| Pull Request Commit  | https://github.com/owner/repo/pull/123/commits/abcdefghijklmnopqrsxyz#diff-123  |
+| Pull Request Commit  | https://github.com/owner/repo/pulls/123/commits/abcdefghijklmnopqrsxyz#diff-123 |

--- a/styles/examples/table_with_footer_auto_links_short.style
+++ b/styles/examples/table_with_footer_auto_links_short.style
@@ -1,0 +1,10 @@
+{
+  "link": {
+    "color": "30",
+    "underline": true
+  },
+  "link_text": {
+    "color": "35",
+    "bold": true
+  }
+}


### PR DESCRIPTION
- Closes https://github.com/charmbracelet/glamour/issues/413
- Follow-up of https://github.com/charmbracelet/glamour/pull/406

Some notes:

- We're prefixing `owner/repo` on every link, without trying to be smart in detecting whether that repo is the current one (always `owner/repo#123` instead of `#123`)
- We're only doing it for links inside tables for now, because only there we're showing a footer with the full link.
  - Soon, when we [add support for OSC 8 hyperlinks](https://github.com/charmbracelet/glamour/pull/411), we can use this pattern everywhere and just add hyperlinks to the link preview (`repo/owner#123` would become clickable)
- Ideas for the future:
  - Additionally to GitHub, we could support more sites like GitLab and other...
  - We could expose something like `WithAutolinkPattern(regexp, func)` to allow uses to code their own custom auto link patterns.

Preview:

![table_with_footer_auto_links_short](https://github.com/user-attachments/assets/718764b9-0d5b-4f61-8b25-18bd18562b3a)
