### PR TITLE
A bug in word wrapping (with a failing test case)

### DIFF
--- a/glamour_test.go
+++ b/glamour_test.go
@@ -325,3 +325,21 @@ func TestWithChromaFormatterCustom(t *testing.T) {
 
 	golden.RequireEqual(t, []byte(b))
 }
+
+func TestWithWordWrap(t *testing.T) {
+	longLine := "Of course. Based on my exploration, this project is a command-line application written in Go. It acts as..."
+
+	r, err := NewTermRenderer(
+		WithWordWrap(88),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := r.Render(longLine)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	golden.RequireEqual(t, []byte(out))
+}

--- a/testdata/TestWithWordWrap.golden
+++ b/testdata/TestWithWordWrap.golden
@@ -1,0 +1,3 @@
+Of course. Based on my exploration, this project is a command-line application written  
+in                                                                                      
+Go. It acts as...                                                                       


### PR DESCRIPTION
This is a failing test case related to #451. I tried to pinpoint the actual bug but could not find it (at least yet).