### PR TITLE
perf(ansi): ensure all PenWriter instances are closed

### DIFF
--- a/ansi/blockelement.go
+++ b/ansi/blockelement.go
@@ -40,6 +40,7 @@ func (e *BlockElement) Finish(w io.Writer, ctx RenderContext) error {
 		)
 
 		mw := NewMarginWriter(ctx, w, bs.Current().Style)
+		defer mw.Close()
 		if _, err := io.WriteString(mw, s); err != nil {
 			return fmt.Errorf("glamour: error writing to writer: %w", err)
 		}

--- a/ansi/codeblock.go
+++ b/ansi/codeblock.go
@@ -128,6 +128,7 @@ func (e *CodeBlockElement) Render(w io.Writer, ctx RenderContext) error {
 	iw := NewIndentWriter(w, int(indentation+margin), func(_ io.Writer) { //nolint:gosec
 		_, _ = renderText(w, bs.Current().Style.StylePrimitive, " ")
 	})
+	defer iw.Close()
 
 	if len(theme) > 0 {
 		_, _ = renderText(iw, bs.Current().Style.StylePrimitive, rules.BlockPrefix)

--- a/ansi/heading.go
+++ b/ansi/heading.go
@@ -63,6 +63,7 @@ func (e *HeadingElement) Finish(w io.Writer, ctx RenderContext) error {
 	bs := ctx.blockStack
 	rules := bs.Current().Style
 	mw := NewMarginWriter(ctx, w, rules)
+	defer mw.Close()
 
 	flow := cellbuf.Wrap(bs.Current().Block.String(), int(bs.Width(ctx)), "") //nolint: gosec
 	_, err := io.WriteString(mw, flow)

--- a/ansi/margin.go
+++ b/ansi/margin.go
@@ -2,6 +2,7 @@ package ansi
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -56,6 +57,15 @@ func (w *MarginWriter) Write(b []byte) (int, error) {
 	return n, nil
 }
 
+func (w *MarginWriter) Close() error {
+	var werr error
+	if w, ok := w.w.(io.WriteCloser); ok {
+		werr = w.Close()
+	}
+
+	return errors.Join(werr, w.iw.Close())
+}
+
 // PaddingFunc is a function that applies padding around whatever you write to it.
 type PaddingFunc = func(w io.Writer)
 
@@ -107,6 +117,10 @@ func (w *PaddingWriter) Write(p []byte) (int, error) {
 	}
 
 	return len(p), nil
+}
+
+func (w *PaddingWriter) Close() error {
+	return w.w.Close()
 }
 
 // IndentFunc is a function that applies indentation around whatever you write to
@@ -186,4 +200,13 @@ func (w *IndentWriter) Write(p []byte) (int, error) {
 	}
 
 	return len(p), nil
+}
+
+func (w *IndentWriter) Close() error {
+	var werr error
+	if w, ok := w.w.(io.WriteCloser); ok {
+		werr = w.Close()
+	}
+
+	return errors.Join(werr, w.pw.Close())
 }

--- a/ansi/paragraph.go
+++ b/ansi/paragraph.go
@@ -39,6 +39,7 @@ func (e *ParagraphElement) Finish(w io.Writer, ctx RenderContext) error {
 	rules := bs.Current().Style
 
 	mw := NewMarginWriter(ctx, w, rules)
+	defer mw.Close()
 	if len(strings.TrimSpace(bs.Current().Block.String())) > 0 {
 		blk := bs.Current().Block.String()
 		if !ctx.options.PreserveNewLines {

--- a/ansi/table.go
+++ b/ansi/table.go
@@ -51,6 +51,7 @@ func (e *TableElement) Render(w io.Writer, ctx RenderContext) error {
 	iw := NewIndentWriter(w, int(indentation+margin), func(_ io.Writer) { //nolint:gosec
 		_, _ = renderText(w, bs.Current().Style.StylePrimitive, " ")
 	})
+	defer iw.Close()
 
 	style := bs.With(rules.StylePrimitive)
 


### PR DESCRIPTION
*This is one of a series of changes related to https://github.com/charmbracelet/crush/issues/691*

------

As explained in https://github.com/charmbracelet/x/pull/518 this is performance critical for complex applications such as `crush`.

This change can be merged before the related change in `x`, but will not have any performance effect until the `x` PR is merged, and the package is updated here.

### Describe your changes

The `PenWriter` type internally uses `x/ansi.Parser` instances, which allocate large buffers. The corresponding change in `x` introduces a pool model for these parsers, making them reusable and reducing allocator/GC pressure **significantly** in complex applications like crush.

### Related issue/discussion

* https://github.com/charmbracelet/crush/issues/691

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code