### PR TITLE
Avoid panic in blockstack if len(s) is 0

### DIFF
--- a/ansi/blockstack.go
+++ b/ansi/blockstack.go
@@ -67,7 +67,7 @@ func (s BlockStack) Width(ctx RenderContext) uint {
 
 // Parent returns the current BlockElement's parent.
 func (s BlockStack) Parent() BlockElement {
-	if len(s) == 1 {
+	if len(s) <= 1 {
 		return BlockElement{
 			Block: &bytes.Buffer{},
 		}


### PR DESCRIPTION
I'm not sure how this is reached or whether the invariant is supposed to be preserved elsewhere, but I encountered a panic here with a basic renderer and untrusted input. This seems like a simple-enough fix.