### PR TITLE
Eat uneaten backslash. Fixes output of \~ (no strikeout).

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -11,6 +11,7 @@ import (
 	east "github.com/yuin/goldmark-emoji/ast"
 	"github.com/yuin/goldmark/ast"
 	astext "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/util"
 )
 
 // ElementRenderer is called when entering a markdown node.
@@ -170,7 +171,7 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 	// Text Elements
 	case ast.KindText:
 		n := node.(*ast.Text)
-		s := string(n.Segment.Value(source))
+		s := string(util.UnescapePunctuations(n.Segment.Value(source)))
 
 		if n.HardLineBreak() || (n.SoftLineBreak()) {
 			s += "\n"


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`]
(https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).

~- [ ] I have created a discussion that was approved by a maintainer (for new features).~

Two commits. The first adds a test for \\\~usage. and then the second fixes issue #503 .

The first commit adds the test, ran using:
```go test ./ansi/ -run TestRendererIssues``` 
which we can then see passes after adding the second commit.