### PR TITLE
docs: add v2 upgrade guide + release notes

### DIFF
--- a/UPGRADE_GUIDE_V2.md
+++ b/UPGRADE_GUIDE_V2.md
@@ -18,13 +18,13 @@ This guide will help you migrate from Glamour v1 to v2. Most upgrades are straig
 ## Update Dependencies
 
 ```bash
-go get charm.land/glamour/v2
+go get charm.land/glamour/v2@latest
 ```
 
 If you need color downsampling (most apps do):
 
 ```bash
-go get charm.land/lipgloss/v2
+go get charm.land/lipgloss/v2@latest
 ```
 
 ## Remove Auto Style Detection


### PR DESCRIPTION
Add v2 upgrade guide

<details>
<summary>Release notes</summary>

# What's New in Glamour v2

We're excited to announce the second major release of Glamour!

<!--
If you (or your LLM) are just looking for technical details on migrating from v1, please check out the [Upgrade Guide](https://github.com/charmbracelet/glamour/tree/main/UPGRADE_GUIDE_V2.md).
-->

> [!NOTE]
> We don't take API changes lightly and strive to make the upgrade process as simple as possible. We believe these changes bring necessary improvements and pave the way for the future. If something feels way off, let us know.

## ❤️ Charm Land Import Path

We've updated our import paths to use vanity domains and use our domain to import Go packages.

```go
// Before
import "github.com/charmbracelet/glamour"

// After
import "charm.land/glamour/v2"
```

## 💄 Lip Gloss v2 Integration

Glamour v2 now uses [Lip Gloss v2][lipgloss] under the hood, bringing improved performance and more consistent styling across the Charm ecosystem.

Since Glamour is designed to be pure (same input = same output), it doesn't peek at your terminal's capabilities. Instead, color downsampling is handled explicitly via Lip Gloss when you're ready to render:

```go
r, _ := glamour.NewTermRenderer(glamour.WithWordWrap(80))
out, _ := r.Render(markdown)

// Downsample colors based on terminal capabilities
lipgloss.Print(out)
```

No more I/O fights between Glamour and Lip Gloss. Glamour focuses on rendering, Lip Gloss handles the colors. Everyone's happy!

[lipgloss]: https://github.com/charmbracelet/lipgloss

## 🌏 Better Text Wrapping

Text wrapping has been rewritten using `lipgloss.Wrap`, which means way better handling of:

- Multi-byte UTF-8 characters (CJK, emojis, etc.)
- Complex Unicode sequences
- Terminal cell width edge cases

Your Japanese documentation, emoji-filled READMEs, and creative Unicode art will all render beautifully now.

## 🔗 Hyperlink Support

Glamour now supports ANSI hyperlinks! If your terminal supports OSC 8 (and many modern terminals do), your links can be clickable. No changes needed, it just works.

```go
md := `Check out [Charm](https://charm.sh) for more awesome tools!`
out, _ := glamour.Render(md, "dark")
fmt.Print(out)
// In supporting terminals, "Charm" will be clickable!
```

<details>
<summary>Which terminals support OSC 8 hyperlinks?</summary>

- [Ghostty](https://mitchellh.com/ghostty)
- [Kitty](https://sw.kovidgoyal.net/kitty/)
- [WezTerm](https://wezfurlong.org/wezterm/)
- [iTerm2](https://iterm2.com) (v3.1+)
- [Foot](https://codeberg.org/dnkl/foot)
- [Alacritty](https://alacritty.org) (v0.13+)
- [Rio](https://raphamorim.io/rio/)
- [VTE-based terminals](https://gitlab.gnome.org/GNOME/vte) (GNOME Terminal, Tilix, etc.)

</details>

## 📧 Cleaner Email Rendering

Email autolinks now hide the `mailto:` prefix for a cleaner look while remaining functional. Because nobody wants to read `mailto:` in their rendered markdown.

```go
// Before (v1): Rendered as "mailto:hello@charm.sh"
md := `Contact us at <hello@charm.sh>`
out, _ := glamour.Render(md, "dark")
// Output: mailto:hello@charm.sh (ugly!)

// After (v2): Rendered as just "hello@charm.sh"
md := `Contact us at <hello@charm.sh>`
out, _ := glamour.Render(md, "dark")
// Output: hello@charm.sh (much better!)
```

## 🌙 Dark is the New Default

The `WithAutoStyle()` option and `AutoStyle` have been removed. The default style is now `"dark"`, which works well across most terminals. You can still explicitly choose any style:

```go
// Use a specific style
out, _ := glamour.Render(markdown, "light")
out, _ := glamour.Render(markdown, "pink")
out, _ := glamour.Render(markdown, "dracula")
out, _ := glamour.Render(markdown, "tokyo-night")
```

Simpler is better!

## 🎨 Color Profile Changes

The `WithColorProfile()` option has been removed. Color adaptation is now handled by Lip Gloss when rendering output:

```go
// Old approach (v1)
r, _ := glamour.NewTermRenderer(
    glamour.WithColorProfile(termenv.TrueColor),
)

// New approach (v2)
r, _ := glamour.NewTermRenderer(glamour.WithWordWrap(80))
out, _ := r.Render(markdown)
lipgloss.Print(out) // Handles color downsampling automatically
```

This separation of concerns makes Glamour's rendering more predictable and testable.

## 👋 Farewell, Overline

The `Overlined` field has been removed from all style primitives. It was rarely used and not widely supported across terminals. If you need similar visual separation, consider using underline, bold, or background colors instead.

## 🐛 Bug Fixes

- Fixed CJK character rendering in margin writers
- Fixed table background colors to match document styling
- Improved handling of edge cases in text wrapping
- Better handling of code spans with special characters

<!--

## 🌈 More on Glamour v2

Ready to migrate? Head over to the [Upgrade Guide](https://github.com/charmbracelet/glamour/tree/main/UPGRADE_GUIDE_V2.md) for the full migration checklist.

-->

## Feedback

Have thoughts on Glamour v2? We'd _love_ to hear about it. Let us know on…

- [Discord](https://charm.sh/chat)
- [The Fediverse](https://mastodon.social/@charmcli)
- [Twitter](https://twitter.com/charmcli)

---

Part of [Charm](https://charm.sh).

<a href="https://charm.sh/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge.jpg" width="400"></a>

Charm热爱开源 • Charm loves open source

</details>