### PR TITLE
docs: fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ There are a few options for using a custom style:
 1. Set the `GLAMOUR_STYLE` environment variable to your desired default style or a file location for a style and call `glamour.RenderWithEnvironmentConfig(inputText)`
 1. Set the `GLAMOUR_STYLE` environment variable and pass `glamour.WithEnvironmentConfig()` to your custom renderer
 
-## Glamourous Projects
+## Glamorous Projects
 
 Check out these projects, which use `glamour`:
 


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

## Summary
- Fix a spelling typo in the README heading.

## Related issue
- N/A (doc wording fix)

## Guideline alignment
- https://github.com/charmbracelet/glamour/contribute

## Validation/testing
- Not run (docs change only)
