### PR TITLE
docs: fix typo in README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ There are a few options for using a custom style:
 1. Set the `GLAMOUR_STYLE` environment variable to your desired default style or a file location for a style and call `glamour.RenderWithEnvironmentConfig(inputText)`
 1. Set the `GLAMOUR_STYLE` environment variable and pass `glamour.WithEnvironmentConfig()` to your custom renderer
 
-## Glamourous Projects
+## Glamorous Projects
 
 Check out these projects, which use `glamour`:
 


### PR DESCRIPTION
## Summary

Fix a typo in the README heading for projects using Glamour.

## Related issue

N/A. This is a trivial docs-only fix.

## Guideline alignment

- Followed the repository contributing guide: https://github.com/charmbracelet/glamour/blob/main/CONTRIBUTING.md
- The change is limited to one README heading and does not affect behavior.

## Validation/testing

Not run. This is a documentation-only change.
