### PR TITLE
feat: add Gruvbox dark theme

### DIFF
--- a/styles/gruvbox.go
+++ b/styles/gruvbox.go
@@ -1,0 +1,231 @@
+package styles
+
+import "charm.land/glamour/v2/ansi"
+
+// GruvboxStyleConfig is the gruvbox dark style.
+var GruvboxStyleConfig = ansi.StyleConfig{
+	Document: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockPrefix: "\n",
+			BlockSuffix: "\n",
+			Color:       stringPtr("#ebdbb2"),
+		},
+		Margin: uintPtr(defaultMargin),
+	},
+	BlockQuote: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Color:  stringPtr("#a89984"),
+			Italic: boolPtr(true),
+		},
+		Indent:      uintPtr(1),
+		IndentToken: stringPtr("│ "),
+	},
+	List: ansi.StyleList{
+		LevelIndent: defaultListIndent,
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color: stringPtr("#ebdbb2"),
+			},
+		},
+	},
+	Heading: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockSuffix: "\n",
+			Color:       stringPtr("#fabd2f"),
+			Bold:        boolPtr(true),
+		},
+	},
+	H1: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix:          " ",
+			Suffix:          " ",
+			Color:           stringPtr("#282828"),
+			BackgroundColor: stringPtr("#fabd2f"),
+			Bold:            boolPtr(true),
+		},
+	},
+	H2: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "## ",
+			Color:  stringPtr("#b8bb26"),
+		},
+	},
+	H3: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "### ",
+			Color:  stringPtr("#83a598"),
+		},
+	},
+	H4: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "#### ",
+			Color:  stringPtr("#d3869b"),
+		},
+	},
+	H5: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "##### ",
+			Color:  stringPtr("#8ec07c"),
+		},
+	},
+	H6: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "###### ",
+			Color:  stringPtr("#a89984"),
+			Bold:   boolPtr(false),
+		},
+	},
+	Strikethrough: ansi.StylePrimitive{
+		CrossedOut: boolPtr(true),
+	},
+	Emph: ansi.StylePrimitive{
+		Color:  stringPtr("#fabd2f"),
+		Italic: boolPtr(true),
+	},
+	Strong: ansi.StylePrimitive{
+		Bold:  boolPtr(true),
+		Color: stringPtr("#fe8019"),
+	},
+	HorizontalRule: ansi.StylePrimitive{
+		Color:  stringPtr("#504945"),
+		Format: "\n--------\n",
+	},
+	Item: ansi.StylePrimitive{
+		BlockPrefix: "• ",
+	},
+	Enumeration: ansi.StylePrimitive{
+		BlockPrefix: ". ",
+		Color:       stringPtr("#83a598"),
+	},
+	Task: ansi.StyleTask{
+		StylePrimitive: ansi.StylePrimitive{},
+		Ticked:         "[✓] ",
+		Unticked:       "[ ] ",
+	},
+	Link: ansi.StylePrimitive{
+		Color:     stringPtr("#83a598"),
+		Underline: boolPtr(true),
+	},
+	LinkText: ansi.StylePrimitive{
+		Color: stringPtr("#d3869b"),
+		Bold:  boolPtr(true),
+	},
+	Image: ansi.StylePrimitive{
+		Color:     stringPtr("#83a598"),
+		Underline: boolPtr(true),
+	},
+	ImageText: ansi.StylePrimitive{
+		Color:  stringPtr("#a89984"),
+		Format: "Image: {{.text}} →",
+	},
+	Code: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Color:           stringPtr("#b8bb26"),
+			BackgroundColor: stringPtr("#3c3836"),
+		},
+	},
+	CodeBlock: ansi.StyleCodeBlock{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color: stringPtr("#d5c4a1"),
+			},
+			Margin: uintPtr(defaultMargin),
+		},
+		Chroma: &ansi.Chroma{
+			Text: ansi.StylePrimitive{
+				Color: stringPtr("#ebdbb2"),
+			},
+			Error: ansi.StylePrimitive{
+				Color:           stringPtr("#ebdbb2"),
+				BackgroundColor: stringPtr("#fb4934"),
+			},
+			Comment: ansi.StylePrimitive{
+				Color: stringPtr("#928374"),
+			},
+			CommentPreproc: ansi.StylePrimitive{
+				Color: stringPtr("#8ec07c"),
+			},
+			Keyword: ansi.StylePrimitive{
+				Color: stringPtr("#fb4934"),
+			},
+			KeywordReserved: ansi.StylePrimitive{
+				Color: stringPtr("#fb4934"),
+			},
+			KeywordNamespace: ansi.StylePrimitive{
+				Color: stringPtr("#fe8019"),
+			},
+			KeywordType: ansi.StylePrimitive{
+				Color: stringPtr("#fabd2f"),
+			},
+			Operator: ansi.StylePrimitive{
+				Color: stringPtr("#fe8019"),
+			},
+			Punctuation: ansi.StylePrimitive{
+				Color: stringPtr("#ebdbb2"),
+			},
+			Name: ansi.StylePrimitive{
+				Color: stringPtr("#ebdbb2"),
+			},
+			NameBuiltin: ansi.StylePrimitive{
+				Color: stringPtr("#fabd2f"),
+			},
+			NameTag: ansi.StylePrimitive{
+				Color: stringPtr("#fb4934"),
+			},
+			NameAttribute: ansi.StylePrimitive{
+				Color: stringPtr("#b8bb26"),
+			},
+			NameClass: ansi.StylePrimitive{
+				Color:     stringPtr("#fabd2f"),
+				Underline: boolPtr(true),
+				Bold:      boolPtr(true),
+			},
+			NameConstant: ansi.StylePrimitive{
+				Color: stringPtr("#d3869b"),
+			},
+			NameDecorator: ansi.StylePrimitive{
+				Color: stringPtr("#b8bb26"),
+			},
+			NameFunction: ansi.StylePrimitive{
+				Color: stringPtr("#b8bb26"),
+			},
+			LiteralNumber: ansi.StylePrimitive{
+				Color: stringPtr("#d3869b"),
+			},
+			LiteralString: ansi.StylePrimitive{
+				Color: stringPtr("#b8bb26"),
+			},
+			LiteralStringEscape: ansi.StylePrimitive{
+				Color: stringPtr("#fe8019"),
+			},
+			GenericDeleted: ansi.StylePrimitive{
+				Color: stringPtr("#fb4934"),
+			},
+			GenericEmph: ansi.StylePrimitive{
+				Color:  stringPtr("#fabd2f"),
+				Italic: boolPtr(true),
+			},
+			GenericInserted: ansi.StylePrimitive{
+				Color: stringPtr("#b8bb26"),
+			},
+			GenericStrong: ansi.StylePrimitive{
+				Color: stringPtr("#fe8019"),
+				Bold:  boolPtr(true),
+			},
+			GenericSubheading: ansi.StylePrimitive{
+				Color: stringPtr("#928374"),
+			},
+			Background: ansi.StylePrimitive{
+				BackgroundColor: stringPtr("#282828"),
+			},
+		},
+	},
+	Table: ansi.StyleTable{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{},
+		},
+	},
+	DefinitionDescription: ansi.StylePrimitive{
+		BlockPrefix: "\n🠶 ",
+	},
+}

--- a/styles/gruvbox.json
+++ b/styles/gruvbox.json
@@ -1,0 +1,203 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "color": "#ebdbb2",
+    "margin": 2
+  },
+  "block_quote": {
+    "color": "#a89984",
+    "italic": true,
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "color": "#ebdbb2",
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "#fabd2f",
+    "bold": true
+  },
+  "h1": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "#282828",
+    "background_color": "#fabd2f",
+    "bold": true
+  },
+  "h2": {
+    "prefix": "## ",
+    "color": "#b8bb26"
+  },
+  "h3": {
+    "prefix": "### ",
+    "color": "#83a598"
+  },
+  "h4": {
+    "prefix": "#### ",
+    "color": "#d3869b"
+  },
+  "h5": {
+    "prefix": "##### ",
+    "color": "#8ec07c"
+  },
+  "h6": {
+    "prefix": "###### ",
+    "color": "#a89984",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "color": "#fabd2f",
+    "italic": true
+  },
+  "strong": {
+    "color": "#fe8019",
+    "bold": true
+  },
+  "hr": {
+    "color": "#504945",
+    "format": "\n--------\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". ",
+    "color": "#83a598"
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "#83a598",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#d3869b",
+    "bold": true
+  },
+  "image": {
+    "color": "#83a598",
+    "underline": true
+  },
+  "image_text": {
+    "color": "#a89984",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "color": "#b8bb26",
+    "background_color": "#3c3836"
+  },
+  "code_block": {
+    "color": "#d5c4a1",
+    "margin": 2,
+    "chroma": {
+      "text": {
+        "color": "#ebdbb2"
+      },
+      "error": {
+        "color": "#ebdbb2",
+        "background_color": "#fb4934"
+      },
+      "comment": {
+        "color": "#928374"
+      },
+      "comment_preproc": {
+        "color": "#8ec07c"
+      },
+      "keyword": {
+        "color": "#fb4934"
+      },
+      "keyword_reserved": {
+        "color": "#fb4934"
+      },
+      "keyword_namespace": {
+        "color": "#fe8019"
+      },
+      "keyword_type": {
+        "color": "#fabd2f"
+      },
+      "operator": {
+        "color": "#fe8019"
+      },
+      "punctuation": {
+        "color": "#ebdbb2"
+      },
+      "name": {
+        "color": "#ebdbb2"
+      },
+      "name_builtin": {
+        "color": "#fabd2f"
+      },
+      "name_tag": {
+        "color": "#fb4934"
+      },
+      "name_attribute": {
+        "color": "#b8bb26"
+      },
+      "name_class": {
+        "color": "#fabd2f",
+        "underline": true,
+        "bold": true
+      },
+      "name_constant": {
+        "color": "#d3869b"
+      },
+      "name_decorator": {
+        "color": "#b8bb26"
+      },
+      "name_exception": {},
+      "name_function": {
+        "color": "#b8bb26"
+      },
+      "name_other": {},
+      "literal": {},
+      "literal_number": {
+        "color": "#d3869b"
+      },
+      "literal_date": {},
+      "literal_string": {
+        "color": "#b8bb26"
+      },
+      "literal_string_escape": {
+        "color": "#fe8019"
+      },
+      "generic_deleted": {
+        "color": "#fb4934"
+      },
+      "generic_emph": {
+        "color": "#fabd2f",
+        "italic": true
+      },
+      "generic_inserted": {
+        "color": "#b8bb26"
+      },
+      "generic_strong": {
+        "color": "#fe8019",
+        "bold": true
+      },
+      "generic_subheading": {
+        "color": "#928374"
+      },
+      "background": {
+        "background_color": "#282828"
+      }
+    }
+  },
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/styles/styles.go
+++ b/styles/styles.go
@@ -18,6 +18,7 @@ const (
 	AsciiStyle      = "ascii" //nolint: revive
 	DarkStyle       = "dark"
 	DraculaStyle    = "dracula"
+	GruvboxStyle    = "gruvbox"
 	TokyoNightStyle = "tokyo-night"
 	LightStyle      = "light"
 	NoTTYStyle      = "notty"
@@ -671,6 +672,7 @@ var (
 
 		// Popular themes
 		DraculaStyle:    &DraculaStyleConfig,
+		GruvboxStyle:    &GruvboxStyleConfig,
 		TokyoNightStyle: &TokyoNightStyleConfig,
 	}
 )


### PR DESCRIPTION
## Summary
- Add a new built-in **Gruvbox dark** color scheme, one of the most requested themes (#168)
- Both Go embedded config (`gruvbox.go`) and JSON definition (`gruvbox.json`) provided
- Registered in `DefaultStyles` as `"gruvbox"`
- Full Chroma syntax highlighting palette with all Gruvbox accent colors

## Gruvbox Palette Used
| Role | Color | Hex |
|------|-------|-----|
| Background | Dark0 | `#282828` |
| Foreground | Light2 | `#ebdbb2` |
| H1 | Yellow (inverted) | `#fabd2f` on `#282828` |
| H2 | Green | `#b8bb26` |
| H3 | Blue | `#83a598` |
| H4 | Purple | `#d3869b` |
| Links | Blue | `#83a598` |
| Keywords | Red | `#fb4934` |
| Strings | Green | `#b8bb26` |

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests unaffected)
- [x] Theme follows same structure as existing Dracula/Tokyo Night themes

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)