### PR TITLE
feat: add GitHub-style alert blockquotes

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -84,9 +84,26 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 
 	// Blockquote
 	case ast.KindBlockquote:
+		style := ctx.options.Styles.BlockQuote
+		alertType := detectAlertType(node, source)
+		if alertType != "" {
+			switch alertType {
+			case "NOTE":
+				style = ctx.options.Styles.AlertNote
+			case "TIP":
+				style = ctx.options.Styles.AlertTip
+			case "IMPORTANT":
+				style = ctx.options.Styles.AlertImportant
+			case "WARNING":
+				style = ctx.options.Styles.AlertWarning
+			case "CAUTION":
+				style = ctx.options.Styles.AlertCaution
+			}
+			stripAlertMarker(node, source, alertType)
+		}
 		e := &BlockElement{
 			Block:  &bytes.Buffer{},
-			Style:  cascadeStyle(ctx.blockStack.Current().Style, ctx.options.Styles.BlockQuote, false),
+			Style:  cascadeStyle(ctx.blockStack.Current().Style, style, false),
 			Margin: true,
 		}
 		return Element{
@@ -477,5 +494,86 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 	default:
 		fmt.Println("Warning: unhandled element", node.Kind().String())
 		return Element{}
+	}
+}
+
+// alertTypes are the supported GitHub-style alert types.
+var alertTypes = []string{"NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"}
+
+// detectAlertType checks if a blockquote node starts with a GitHub-style alert
+// marker like [!NOTE], [!TIP], [!IMPORTANT], [!WARNING], or [!CAUTION].
+// Goldmark splits "[!NOTE]" into separate text nodes: "[", "!NOTE", "]",
+// so this function reconstructs the text from consecutive nodes.
+// Returns the alert type string (e.g. "NOTE") or empty string if not an alert.
+func detectAlertType(node ast.Node, source []byte) string {
+	if node.FirstChild() == nil {
+		return ""
+	}
+	firstChild := node.FirstChild()
+	if firstChild.Kind() != ast.KindParagraph {
+		return ""
+	}
+
+	// Collect text from the first few text nodes to reconstruct potential marker
+	var combined string
+	n := firstChild.FirstChild()
+	for n != nil && n.Kind() == ast.KindText {
+		combined += string(n.(*ast.Text).Segment.Value(source))
+		n = n.NextSibling()
+		// Stop after collecting enough text for a marker check
+		if len(combined) > 15 {
+			break
+		}
+	}
+
+	for _, at := range alertTypes {
+		if strings.HasPrefix(combined, "[!"+at+"]") {
+			return at
+		}
+	}
+	return ""
+}
+
+// stripAlertMarker removes the [!TYPE] marker text nodes from the first
+// paragraph of a blockquote. Goldmark splits "[!NOTE]" into separate text
+// nodes: "[", "!NOTE", "]", so we remove all nodes that form the marker.
+func stripAlertMarker(node ast.Node, source []byte, alertType string) {
+	para := node.FirstChild()
+	if para == nil || para.Kind() != ast.KindParagraph {
+		return
+	}
+
+	marker := "[!" + alertType + "]"
+	var consumed int
+	var toRemove []ast.Node
+
+	n := para.FirstChild()
+	for n != nil && n.Kind() == ast.KindText {
+		tn := n.(*ast.Text)
+		text := string(tn.Segment.Value(source))
+		remaining := marker[consumed:]
+
+		if len(text) <= len(remaining) && strings.HasPrefix(remaining, text) {
+			// This entire text node is part of the marker
+			consumed += len(text)
+			toRemove = append(toRemove, n)
+			n = n.NextSibling()
+		} else if strings.HasPrefix(text, remaining) {
+			// This text node contains the end of the marker and more text
+			consumed += len(remaining)
+			tn.Segment.Start += len(remaining)
+			break
+		} else {
+			break
+		}
+
+		if consumed >= len(marker) {
+			break
+		}
+	}
+
+	// Remove all text nodes that were fully consumed by the marker
+	for _, r := range toRemove {
+		para.RemoveChild(para, r)
 	}
 }

--- a/ansi/style.go
+++ b/ansi/style.go
@@ -135,6 +135,13 @@ type StyleConfig struct {
 
 	HTMLBlock StyleBlock `json:"html_block,omitempty"`
 	HTMLSpan  StyleBlock `json:"html_span,omitempty"`
+
+	// GitHub-style alerts (> [!NOTE], > [!TIP], etc.)
+	AlertNote      StyleBlock `json:"alert_note,omitempty"`
+	AlertTip       StyleBlock `json:"alert_tip,omitempty"`
+	AlertImportant StyleBlock `json:"alert_important,omitempty"`
+	AlertWarning   StyleBlock `json:"alert_warning,omitempty"`
+	AlertCaution   StyleBlock `json:"alert_caution,omitempty"`
 }
 
 func cascadeStyles(s ...StyleBlock) StyleBlock {

--- a/styles/dark.json
+++ b/styles/dark.json
@@ -187,5 +187,35 @@
     "block_prefix": "\n🠶 "
   },
   "html_block": {},
-  "html_span": {}
+  "html_span": {},
+  "alert_note": {
+    "color": "39",
+    "block_prefix": "ℹ️  Note\n",
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "alert_tip": {
+    "color": "35",
+    "block_prefix": "💡 Tip\n",
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "alert_important": {
+    "color": "135",
+    "block_prefix": "❗ Important\n",
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "alert_warning": {
+    "color": "214",
+    "block_prefix": "⚠️  Warning\n",
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "alert_caution": {
+    "color": "196",
+    "block_prefix": "🛑 Caution\n",
+    "indent": 1,
+    "indent_token": "│ "
+  }
 }

--- a/styles/styles.go
+++ b/styles/styles.go
@@ -147,6 +147,46 @@ var (
 			Indent:         uintPtr(1),
 			IndentToken:    stringPtr("│ "),
 		},
+		AlertNote: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:       stringPtr("39"),
+				BlockPrefix: "ℹ️  Note\n",
+			},
+			Indent:      uintPtr(1),
+			IndentToken: stringPtr("│ "),
+		},
+		AlertTip: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:       stringPtr("35"),
+				BlockPrefix: "💡 Tip\n",
+			},
+			Indent:      uintPtr(1),
+			IndentToken: stringPtr("│ "),
+		},
+		AlertImportant: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:       stringPtr("135"),
+				BlockPrefix: "❗ Important\n",
+			},
+			Indent:      uintPtr(1),
+			IndentToken: stringPtr("│ "),
+		},
+		AlertWarning: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:       stringPtr("214"),
+				BlockPrefix: "⚠️  Warning\n",
+			},
+			Indent:      uintPtr(1),
+			IndentToken: stringPtr("│ "),
+		},
+		AlertCaution: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:       stringPtr("196"),
+				BlockPrefix: "🛑 Caution\n",
+			},
+			Indent:      uintPtr(1),
+			IndentToken: stringPtr("│ "),
+		},
 		List: ansi.StyleList{
 			LevelIndent: defaultListIndent,
 		},
@@ -356,6 +396,46 @@ var (
 			StylePrimitive: ansi.StylePrimitive{},
 			Indent:         uintPtr(1),
 			IndentToken:    stringPtr("│ "),
+		},
+		AlertNote: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:       stringPtr("27"),
+				BlockPrefix: "ℹ️  Note\n",
+			},
+			Indent:      uintPtr(1),
+			IndentToken: stringPtr("│ "),
+		},
+		AlertTip: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:       stringPtr("29"),
+				BlockPrefix: "💡 Tip\n",
+			},
+			Indent:      uintPtr(1),
+			IndentToken: stringPtr("│ "),
+		},
+		AlertImportant: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:       stringPtr("91"),
+				BlockPrefix: "❗ Important\n",
+			},
+			Indent:      uintPtr(1),
+			IndentToken: stringPtr("│ "),
+		},
+		AlertWarning: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:       stringPtr("172"),
+				BlockPrefix: "⚠️  Warning\n",
+			},
+			Indent:      uintPtr(1),
+			IndentToken: stringPtr("│ "),
+		},
+		AlertCaution: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:       stringPtr("160"),
+				BlockPrefix: "🛑 Caution\n",
+			},
+			Indent:      uintPtr(1),
+			IndentToken: stringPtr("│ "),
 		},
 		List: ansi.StyleList{
 			LevelIndent: defaultListIndent,


### PR DESCRIPTION
## Summary
- Implement rendering support for GitHub-style alert syntax in blockquotes (`> [!NOTE]`, `> [!TIP]`, etc.)
- Each alert type gets a distinct color and emoji-prefixed label
- The `[!TYPE]` marker is automatically stripped from the rendered output
- Regular blockquotes without alert markers are completely unaffected

## Supported Alert Types
| Syntax | Label | Color |
|--------|-------|-------|
| `> [!NOTE]` | ℹ️ Note | Blue |
| `> [!TIP]` | 💡 Tip | Green |
| `> [!IMPORTANT]` | ❗ Important | Purple |
| `> [!WARNING]` | ⚠️ Warning | Orange |
| `> [!CAUTION]` | 🛑 Caution | Red |

## Implementation
- Added `AlertNote`, `AlertTip`, `AlertImportant`, `AlertWarning`, `AlertCaution` fields to `StyleConfig`
- `detectAlertType()` reconstructs the marker from goldmark's fragmented text nodes (`[`, `!NOTE`, `]`)
- `stripAlertMarker()` removes the marker nodes from the AST before rendering
- Alert styles added to `DarkStyleConfig`, `LightStyleConfig`, and `dark.json`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Manual testing confirms all 5 alert types render correctly
- [x] Regular blockquotes unaffected

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)