### PR TITLE
fix: make theme name lookup case-insensitive

### DIFF
--- a/glamour.go
+++ b/glamour.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/yuin/goldmark"
 	emoji "github.com/yuin/goldmark-emoji"
@@ -286,9 +287,9 @@ func getEnvironmentStyle() string {
 }
 
 func getDefaultStyle(style string) (*ansi.StyleConfig, error) {
-	styles, ok := styles.DefaultStyles[style]
+	s, ok := styles.DefaultStyles[strings.ToLower(style)]
 	if !ok {
 		return nil, fmt.Errorf("%s: style not found", style)
 	}
-	return styles, nil
+	return s, nil
 }


### PR DESCRIPTION
## Summary
- Theme names are now case-insensitive: `"Dark"`, `"DARK"`, `"dark"` all work
- One-line fix: `strings.ToLower()` before map lookup in `getDefaultStyle()`

## Problem
```go
// This works:
glamour.Render(md, "dark")
// These fail with "style not found":
glamour.Render(md, "Dark")
glamour.Render(md, "DARK")
// Same issue with GLAMOUR_STYLE env var
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)