### PR TITLE
feat: render inline HTML formatting tags (b, i, u, s, strong, em)

### DIFF
--- a/ansi/context.go
+++ b/ansi/context.go
@@ -15,15 +15,19 @@ type RenderContext struct {
 	table      *TableElement
 
 	stripper *bluemonday.Policy
+
+	// htmlStyleStack tracks active inline HTML style tags (<b>, <i>, <u>, etc.)
+	htmlStyleStack *[]StylePrimitive
 }
 
 // NewRenderContext returns a new RenderContext.
 func NewRenderContext(options Options) RenderContext {
 	return RenderContext{
-		options:    options,
-		blockStack: &BlockStack{},
-		table:      &TableElement{},
-		stripper:   bluemonday.StrictPolicy(),
+		options:        options,
+		blockStack:     &BlockStack{},
+		table:          &TableElement{},
+		stripper:       bluemonday.StrictPolicy(),
+		htmlStyleStack: &[]StylePrimitive{},
 	}
 }
 
@@ -35,4 +39,52 @@ func (ctx RenderContext) SanitizeHTML(s string, trimSpaces bool) string {
 	}
 
 	return html.UnescapeString(s)
+}
+
+// htmlInlineTagStyle returns a StylePrimitive for recognized inline HTML tags.
+// Returns the style and true if the tag is recognized, false otherwise.
+func htmlInlineTagStyle(tag string) (StylePrimitive, bool) {
+	t := true
+	switch strings.ToLower(strings.TrimSpace(tag)) {
+	case "<b>", "<strong>":
+		return StylePrimitive{Bold: &t}, true
+	case "<i>", "<em>":
+		return StylePrimitive{Italic: &t}, true
+	case "<u>", "<ins>":
+		return StylePrimitive{Underline: &t}, true
+	case "<s>", "<del>", "<strike>":
+		return StylePrimitive{CrossedOut: &t}, true
+	}
+	return StylePrimitive{}, false
+}
+
+// isHTMLClosingTag checks if a tag is a closing variant of an inline style tag.
+func isHTMLClosingTag(tag string) bool {
+	switch strings.ToLower(strings.TrimSpace(tag)) {
+	case "</b>", "</strong>", "</i>", "</em>", "</u>", "</ins>", "</s>", "</del>", "</strike>":
+		return true
+	}
+	return false
+}
+
+// PushHTMLStyle adds an inline HTML style to the stack.
+func (ctx RenderContext) PushHTMLStyle(s StylePrimitive) {
+	*ctx.htmlStyleStack = append(*ctx.htmlStyleStack, s)
+}
+
+// PopHTMLStyle removes the last inline HTML style from the stack.
+func (ctx RenderContext) PopHTMLStyle() {
+	stack := *ctx.htmlStyleStack
+	if len(stack) > 0 {
+		*ctx.htmlStyleStack = stack[:len(stack)-1]
+	}
+}
+
+// CurrentHTMLStyle returns the combined style of all active HTML inline tags.
+func (ctx RenderContext) CurrentHTMLStyle() StylePrimitive {
+	var combined StylePrimitive
+	for _, s := range *ctx.htmlStyleStack {
+		combined = cascadeStylePrimitive(combined, s, false)
+	}
+	return combined
 }

--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -175,10 +175,14 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		if n.HardLineBreak() || (n.SoftLineBreak()) {
 			s += "\n"
 		}
+		textStyle := ctx.options.Styles.Text
+		if htmlStyle := ctx.CurrentHTMLStyle(); htmlStyle != (StylePrimitive{}) {
+			textStyle = cascadeStylePrimitive(textStyle, htmlStyle, false)
+		}
 		return Element{
 			Renderer: &BaseElement{
 				Token: html.UnescapeString(s),
-				Style: ctx.options.Styles.Text,
+				Style: textStyle,
 			},
 		}
 
@@ -422,9 +426,21 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		}
 	case ast.KindRawHTML:
 		n := node.(*ast.RawHTML)
+		tag := string(n.Text(source)) //nolint: staticcheck
+
+		// Handle inline formatting tags: <b>, <i>, <u>, <s>, <strong>, <em>, etc.
+		if style, ok := htmlInlineTagStyle(tag); ok {
+			ctx.PushHTMLStyle(style)
+			return Element{}
+		}
+		if isHTMLClosingTag(tag) {
+			ctx.PopHTMLStyle()
+			return Element{}
+		}
+
 		return Element{
 			Renderer: &BaseElement{
-				Token: ctx.SanitizeHTML(string(n.Text(source)), true), //nolint: staticcheck
+				Token: ctx.SanitizeHTML(tag, true),
 				Style: ctx.options.Styles.HTMLSpan.StylePrimitive,
 			},
 		}


### PR DESCRIPTION
## Summary
- Render `<b>`, `<i>`, `<u>`, `<s>` and their semantic variants as ANSI bold/italic/underline/strikethrough
- Nesting works: `<b><i>bold italic</i></b>` renders correctly
- Unrecognized HTML tags are still stripped by bluemonday (no security impact)

## Supported Tags
| HTML | ANSI | Also |
|------|------|------|
| `<b>` | Bold | `<strong>` |
| `<i>` | Italic | `<em>` |
| `<u>` | Underline | `<ins>` |
| `<s>` | Strikethrough | `<del>`, `<strike>` |

## Implementation
- Added `htmlStyleStack` to `RenderContext` (pointer-based for cross-call persistence)
- Opening tags push style, closing tags pop style
- Text nodes apply the combined stack style via `cascadeStylePrimitive()`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Manual testing: bold, italic, underline, strikethrough, and nested combinations all render correctly

Closes #180, Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)