### PR TITLE
fix: render paragraphs in loose list items correctly

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -69,9 +69,11 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 
 	// Paragraph
 	case ast.KindParagraph:
-		if node.Parent() != nil {
-			kind := node.Parent().Kind()
-			if kind == ast.KindListItem {
+		if node.Parent() != nil && node.Parent().Kind() == ast.KindListItem {
+			// Skip the first paragraph in a list item — the item itself
+			// handles rendering. Subsequent paragraphs (loose lists) need
+			// to be rendered with proper separation.
+			if node.PreviousSibling() == nil {
 				return Element{}
 			}
 		}


### PR DESCRIPTION
## Summary
- Fix paragraphs inside loose list items collapsing into the first line

## Problem
```markdown
- item1

  paragraph in list

- item2
```
Rendered as: `• item1paragraph in list` (no separation)

## Fix
Only skip the **first** paragraph inside a list item (already rendered by the item). Subsequent paragraphs get proper `ParagraphElement` rendering.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)