### PR TITLE
fix: add \~ (tilde) to the escape replacer table

### DIFF
--- a/ansi/baseelement.go
+++ b/ansi/baseelement.go
@@ -154,4 +154,5 @@ var escapeReplacer = strings.NewReplacer(
 	"\\.", ".",
 	"\\!", "!",
 	"\\|", "|",
+	"\\~", "~",
 )


### PR DESCRIPTION
## Summary
- Add `\~` → `~` to the `escapeReplacer` in baseelement.go
- One-line fix for escaped tilde not being processed

## Problem
Writing `\~` in markdown rendered literally as `\~` instead of `~`. Important when GFM strikethrough (`~~text~~`) is enabled — users need `\~` to write a literal tilde.

## Fix
Add the missing entry to the replacer table, consistent with all other escaped punctuation (`\*`, `\[`, `\!`, etc.).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)