### PR TITLE
fix: preserve HTML entities verbatim in code spans

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -366,7 +366,10 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		s := string(n.Text(source)) //nolint: staticcheck
 		return Element{
 			Renderer: &CodeSpanElement{
-				Text:  html.UnescapeString(s),
+				// Code spans should preserve content verbatim — do not unescape
+				// HTML entities like &amp; &lt; etc. since they are literal text
+				// inside inline code.
+				Text:  s,
 				Style: cascadeStyle(ctx.blockStack.Current().Style, ctx.options.Styles.Code, false).StylePrimitive,
 			},
 		}


### PR DESCRIPTION
## Summary
- Stop unescaping HTML entities inside code spans (`&amp;` → `&amp;`, not `&`)

## Problem
```markdown
Use `&amp;` for ampersand and `&lt;` for less-than
```
Rendered as: `&` and `<` — but should stay as `&amp;` and `&lt;`

## Fix
Remove `html.UnescapeString()` from code span text. Code spans are verbatim by definition.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)