### PR TITLE
feat: add AutoStyle for automatic NoTTY fallback

### DIFF
--- a/glamour.go
+++ b/glamour.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"os"
 
+	"golang.org/x/term"
+
 	"github.com/yuin/goldmark"
 	emoji "github.com/yuin/goldmark-emoji"
 	"github.com/yuin/goldmark/extension"
@@ -24,6 +26,12 @@ import (
 const (
 	defaultWidth = 80
 	highPriority = 1000
+
+	// AutoStyle automatically selects a style based on the terminal.
+	// When stdout is a TTY, it uses DarkStyle. When stdout is not a TTY
+	// (e.g. piped to a file or another command), it falls back to NoTTYStyle
+	// which strips ANSI escape sequences.
+	AutoStyle = "auto"
 )
 
 // A TermRendererOption sets an option on a TermRenderer.
@@ -286,9 +294,18 @@ func getEnvironmentStyle() string {
 }
 
 func getDefaultStyle(style string) (*ansi.StyleConfig, error) {
-	styles, ok := styles.DefaultStyles[style]
+	// Auto-detect: use NoTTY when stdout is not a terminal
+	if style == AutoStyle {
+		if term.IsTerminal(int(os.Stdout.Fd())) {
+			style = styles.DarkStyle
+		} else {
+			style = styles.NoTTYStyle
+		}
+	}
+
+	s, ok := styles.DefaultStyles[style]
 	if !ok {
 		return nil, fmt.Errorf("%s: style not found", style)
 	}
-	return styles, nil
+	return s, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/yuin/goldmark v1.7.8
 	github.com/yuin/goldmark-emoji v1.0.5
+	golang.org/x/term v0.31.0
 	golang.org/x/text v0.24.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -61,5 +61,7 @@ golang.org/x/sync v0.18.0 h1:kr88TuHDroi+UVf+0hZnirlk8o8T+4MrK6mr60WkH/I=
 golang.org/x/sync v0.18.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=
+golang.org/x/term v0.31.0/go.mod h1:R4BeIy7D95HzImkxGkTW1UQTtP54tio2RyHz7PwK0aw=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=


### PR DESCRIPTION
## Summary
- Add `glamour.AutoStyle` constant that auto-detects TTY and selects DarkStyle or NoTTYStyle
- Clean output when piped, colored output when interactive

## Usage
```go
glamour.Render(markdown, glamour.AutoStyle)
```
- Terminal → DarkStyle (ANSI colors)
- Pipe/redirect → NoTTYStyle (plain ASCII)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)