### PR TITLE
feat: add WithHiddenLinks option to hide URL display

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -249,7 +249,7 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 				BaseURL:  ctx.options.BaseURL,
 				URL:      string(n.Destination),
 				Children: children,
-				SkipHref: isFooterLinks,
+				SkipHref: isFooterLinks || ctx.options.HideLinks,
 			},
 		}
 	case ast.KindAutoLink:

--- a/ansi/renderer.go
+++ b/ansi/renderer.go
@@ -20,6 +20,7 @@ type Options struct {
 	TableWrap        *bool
 	InlineTableLinks bool
 	PreserveNewLines bool
+	HideLinks        bool
 	Styles           StyleConfig
 	ChromaFormatter  string
 }

--- a/glamour.go
+++ b/glamour.go
@@ -196,6 +196,16 @@ func WithInlineTableLinks(inlineTableLinks bool) TermRendererOption {
 	}
 }
 
+// WithHiddenLinks hides the URL portion of links, showing only the link text.
+// This is useful when the terminal supports OSC 8 hyperlinks (clickable links)
+// and displaying the raw URL is redundant.
+func WithHiddenLinks() TermRendererOption {
+	return func(tr *TermRenderer) error {
+		tr.ansiOptions.HideLinks = true
+		return nil
+	}
+}
+
 // WithPreservedNewLines preserves newlines from being replaced.
 func WithPreservedNewLines() TermRendererOption {
 	return func(tr *TermRenderer) error {


### PR DESCRIPTION
## Summary
- Add `WithHiddenLinks()` option that hides URL display, showing only link text
- Useful for OSC 8-capable terminals where URLs are clickable

## Usage
```go
r, _ := glamour.NewTermRenderer(
    glamour.WithStandardStyle("dark"),
    glamour.WithHiddenLinks(),
)
```
Before: `click here https://example.com`
After: `click here` (clickable via OSC 8)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)