### PR TITLE
feat: add no_wrap style option to disable word wrapping per element

### DIFF
--- a/ansi/blockelement.go
+++ b/ansi/blockelement.go
@@ -33,11 +33,13 @@ func (e *BlockElement) Finish(w io.Writer, ctx RenderContext) error {
 	bs := ctx.blockStack
 
 	if e.Margin { //nolint: nestif
-		s := lipgloss.Wrap(
-			bs.Current().Block.String(),
-			int(bs.Width(ctx)), //nolint: gosec
-			" ,.;-+|",
-		)
+		content := bs.Current().Block.String()
+		var s string
+		if e.Style.NoWrap != nil && *e.Style.NoWrap {
+			s = content
+		} else {
+			s = lipgloss.Wrap(content, int(bs.Width(ctx)), " ,.;-+|") //nolint: gosec
+		}
 
 		mw := NewMarginWriter(ctx, w, bs.Current().Style)
 		defer mw.Close() //nolint:errcheck

--- a/ansi/style.go
+++ b/ansi/style.go
@@ -70,6 +70,7 @@ type StyleBlock struct {
 	Indent      *uint   `json:"indent,omitempty"`
 	IndentToken *string `json:"indent_token,omitempty"`
 	Margin      *uint   `json:"margin,omitempty"`
+	NoWrap      *bool   `json:"no_wrap,omitempty"`
 }
 
 // StyleCodeBlock holds the style settings for a code block.


### PR DESCRIPTION
## Summary
- Add `no_wrap` field to `StyleBlock` that disables word wrapping per element

## Problem
Some elements (like code blocks or pre-formatted text) should not have their content word-wrapped, but there was no way to opt out of wrapping on a per-element basis.

## Solution
New `NoWrap` boolean field in `StyleBlock`. When set to `true`, `BlockElement.Finish()` skips the `lipgloss.Wrap()` call and renders content as-is.

```json
"code_block": { "no_wrap": true }
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Backwards compatible — elements without `no_wrap` behave as before

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)