### PR TITLE
feat: add fill style option for full-width background color

### DIFF
--- a/ansi/heading.go
+++ b/ansi/heading.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // A HeadingElement is used to render headings.
@@ -66,6 +68,16 @@ func (e *HeadingElement) Finish(w io.Writer, ctx RenderContext) error {
 	defer mw.Close() //nolint:errcheck
 
 	flow := lipgloss.Wrap(bs.Current().Block.String(), int(bs.Width(ctx)), "") //nolint: gosec
+
+	// Fill the line with background color if Fill is enabled
+	if rules.Fill != nil && *rules.Fill {
+		width := int(bs.Width(ctx)) //nolint: gosec
+		stripped := ansi.Strip(flow)
+		if pad := width - ansi.StringWidth(stripped); pad > 0 {
+			flow += strings.Repeat(" ", pad)
+		}
+	}
+
 	_, err := io.WriteString(mw, flow)
 	if err != nil {
 		return fmt.Errorf("glamour: error writing to writer: %w", err)

--- a/ansi/style.go
+++ b/ansi/style.go
@@ -55,6 +55,7 @@ type StylePrimitive struct {
 	Inverse         *bool   `json:"inverse,omitempty"`
 	Blink           *bool   `json:"blink,omitempty"`
 	Format          string  `json:"format,omitempty"`
+	Fill            *bool   `json:"fill,omitempty"`
 }
 
 // StyleTask holds the style settings for a task item.


### PR DESCRIPTION
Extends heading background color to fill the entire line width.

```json
"h1": { "background_color": "#5c5cff", "fill": true }
```

Closes #454
🤖 Generated with [Claude Code](https://claude.com/claude-code)