### PR TITLE
fix: allow runtime theme changes to apply to code blocks

### DIFF
--- a/ansi/codeblock.go
+++ b/ansi/codeblock.go
@@ -84,9 +84,10 @@ func (e *CodeBlockElement) Render(w io.Writer, ctx RenderContext) error {
 	if rules.Chroma != nil {
 		theme = chromaStyleTheme
 		mutex.Lock()
-		// Don't register the style if it's already registered.
-		_, ok := styles.Registry[theme]
-		if !ok {
+		// Always re-register the style to support runtime theme changes.
+		// Previously, the style was only registered once, which prevented
+		// switching themes while the application is running (#436).
+		{
 			styles.Register(chroma.MustNewStyle(theme,
 				chroma.StyleEntries{
 					chroma.Text:                chromaStyle(rules.Chroma.Text),
@@ -123,7 +124,7 @@ func (e *CodeBlockElement) Render(w io.Writer, ctx RenderContext) error {
 				}))
 		}
 		mutex.Unlock()
-	}
+	} //nolint:wsl
 
 	iw := NewIndentWriter(w, int(indentation+margin), func(_ io.Writer) { //nolint:gosec
 		_, _ = renderText(w, bs.Current().Style.StylePrimitive, " ")


### PR DESCRIPTION
## Summary
- Fix code blocks not updating when switching themes at runtime

## Problem
When creating a new `TermRenderer` with a different style and re-rendering, code block syntax highlighting kept using the old Chroma theme. This made runtime theme switching impossible for code blocks.

## Root Cause
The Chroma style was registered once in `styles.Registry["glamour"]` and reused on subsequent renders, even when the `StyleConfig` had changed.

## Fix
Always re-register the Chroma style when a `Chroma` config is present, replacing the cached version.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)