### PR TITLE
feat(style): gruvbox-dark and -light

### DIFF
--- a/styles/gruvbox-dark.go
+++ b/styles/gruvbox-dark.go
@@ -1,0 +1,229 @@
+package styles
+
+import "charm.land/glamour/v2/ansi"
+
+// GruvboxDarkStyleConfig is the Gruvbox dark style.
+var GruvboxDarkStyleConfig = ansi.StyleConfig{
+	Document: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockPrefix: "\n",
+			BlockSuffix: "\n",
+			Color:       stringPtr("#ebdbb2"),
+		},
+		Margin: uintPtr(defaultMargin),
+	},
+	BlockQuote: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Color:  stringPtr("#d3869b"),
+			Italic: boolPtr(true),
+		},
+		Indent:      uintPtr(2),
+		IndentToken: stringPtr("│ "),
+	},
+	List: ansi.StyleList{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color: stringPtr("#ebdbb2"),
+			},
+		},
+		LevelIndent: defaultListIndent,
+	},
+	Heading: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockSuffix: "\n",
+			Color:       stringPtr("#83a598"),
+			Bold:        boolPtr(true),
+		},
+	},
+	H1: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "# ",
+			Color:  stringPtr("#83a598"),
+			Bold:   boolPtr(true),
+		},
+	},
+	H2: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "## ",
+			Color:  stringPtr("#83a598"),
+			Bold:   boolPtr(true),
+		},
+	},
+	H3: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "### ",
+			Color:  stringPtr("#8ec07c"),
+			Bold:   boolPtr(true),
+		},
+	},
+	H4: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "#### ",
+			Color:  stringPtr("#fabd2f"),
+			Bold:   boolPtr(true),
+		},
+	},
+	H5: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "##### ",
+			Color:  stringPtr("#fe8019"),
+		},
+	},
+	H6: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "###### ",
+			Color:  stringPtr("#fb4934"),
+		},
+	},
+	Strikethrough: ansi.StylePrimitive{
+		CrossedOut: boolPtr(true),
+	},
+	Emph: ansi.StylePrimitive{
+		Color:  stringPtr("#d3869b"),
+		Italic: boolPtr(true),
+	},
+	Strong: ansi.StylePrimitive{
+		Color: stringPtr("#fe8019"),
+		Bold:  boolPtr(true),
+	},
+	HorizontalRule: ansi.StylePrimitive{
+		Color:  stringPtr("#a89984"),
+		Format: "\n--------\n",
+	},
+	Item: ansi.StylePrimitive{
+		BlockPrefix: "• ",
+	},
+	Enumeration: ansi.StylePrimitive{
+		BlockPrefix: ". ",
+	},
+	Task: ansi.StyleTask{
+		StylePrimitive: ansi.StylePrimitive{},
+		Ticked:         "[✓] ",
+		Unticked:       "[ ] ",
+	},
+	Link: ansi.StylePrimitive{
+		Color:     stringPtr("#83a598"),
+		Underline: boolPtr(true),
+	},
+	LinkText: ansi.StylePrimitive{
+		Color: stringPtr("#83a598"),
+		Bold:  boolPtr(true),
+	},
+	Image: ansi.StylePrimitive{
+		Color:     stringPtr("#fe8019"),
+		Underline: boolPtr(true),
+	},
+	ImageText: ansi.StylePrimitive{
+		Color:  stringPtr("#928374"),
+		Format: "Image: {{.text}} →",
+	},
+	Code: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix:          " ",
+			Suffix:          " ",
+			Color:           stringPtr("#fb4934"),
+			BackgroundColor: stringPtr("#3c3836"),
+		},
+	},
+	CodeBlock: ansi.StyleCodeBlock{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color: stringPtr("#ebdbb2"),
+			},
+			Margin: uintPtr(defaultMargin),
+		},
+		Chroma: &ansi.Chroma{
+			Text: ansi.StylePrimitive{
+				Color: stringPtr("#ebdbb2"),
+			},
+			Error: ansi.StylePrimitive{
+				Color:           stringPtr("#282828"),
+				BackgroundColor: stringPtr("#fb4934"),
+			},
+			Comment: ansi.StylePrimitive{
+				Color: stringPtr("#928374"),
+			},
+			CommentPreproc: ansi.StylePrimitive{
+				Color: stringPtr("#fe8019"),
+			},
+			Keyword: ansi.StylePrimitive{
+				Color: stringPtr("#83a598"),
+			},
+			KeywordReserved: ansi.StylePrimitive{
+				Color: stringPtr("#d3869b"),
+			},
+			KeywordNamespace: ansi.StylePrimitive{
+				Color: stringPtr("#fb4934"),
+			},
+			KeywordType: ansi.StylePrimitive{
+				Color: stringPtr("#8ec07c"),
+			},
+			Operator: ansi.StylePrimitive{
+				Color: stringPtr("#fb4934"),
+			},
+			Punctuation: ansi.StylePrimitive{
+				Color: stringPtr("#fb4934"),
+			},
+			NameBuiltin: ansi.StylePrimitive{
+				Color: stringPtr("#83a598"),
+			},
+			NameTag: ansi.StylePrimitive{
+				Color: stringPtr("#8ec07c"),
+			},
+			NameAttribute: ansi.StylePrimitive{
+				Color: stringPtr("#8ec07c"),
+			},
+			NameClass: ansi.StylePrimitive{
+				Color:     stringPtr("#ebdbb2"),
+				Underline: boolPtr(true),
+				Bold:      boolPtr(true),
+			},
+			NameConstant: ansi.StylePrimitive{
+				Color: stringPtr("#8ec07c"),
+			},
+			NameDecorator: ansi.StylePrimitive{
+				Color: stringPtr("#fabd2f"),
+			},
+			NameFunction: ansi.StylePrimitive{
+				Color: stringPtr("#83a598"),
+			},
+			LiteralNumber: ansi.StylePrimitive{
+				Color: stringPtr("#fabd2f"),
+			},
+			LiteralString: ansi.StylePrimitive{
+				Color: stringPtr("#b8bb26"),
+			},
+			LiteralStringEscape: ansi.StylePrimitive{
+				Color: stringPtr("#8ec07c"),
+			},
+			GenericDeleted: ansi.StylePrimitive{
+				Color: stringPtr("#fb4934"),
+			},
+			GenericEmph: ansi.StylePrimitive{
+				Italic: boolPtr(true),
+			},
+			GenericInserted: ansi.StylePrimitive{
+				Color: stringPtr("#b8bb26"),
+			},
+			GenericStrong: ansi.StylePrimitive{
+				Bold: boolPtr(true),
+			},
+			GenericSubheading: ansi.StylePrimitive{
+				Color: stringPtr("#928374"),
+			},
+			Background: ansi.StylePrimitive{
+				BackgroundColor: stringPtr("#32302f"),
+			},
+		},
+	},
+	Table: ansi.StyleTable{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{},
+		},
+	},
+	DefinitionDescription: ansi.StylePrimitive{
+		BlockPrefix: "\n🠶 ",
+	},
+	HTMLBlock: ansi.StyleBlock{},
+	HTMLSpan:  ansi.StyleBlock{},
+}

--- a/styles/gruvbox-dark.json
+++ b/styles/gruvbox-dark.json
@@ -1,0 +1,200 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "color": "#ebdbb2",
+    "margin": 2
+  },
+  "block_quote": {
+    "color": "#d3869b",
+    "italic": true,
+    "indent": 2,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "color": "#ebdbb2",
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "#83a598",
+    "bold": true
+  },
+  "h1": {
+    "prefix": "# ",
+    "color": "#83a598",
+    "bold": true
+  },
+  "h2": {
+    "prefix": "## ",
+    "color": "#83a598",
+    "bold": true
+  },
+  "h3": {
+    "prefix": "### ",
+    "color": "#8ec07c",
+    "bold": true
+  },
+  "h4": {
+    "prefix": "#### ",
+    "color": "#fabd2f",
+    "bold": true
+  },
+  "h5": {
+    "prefix": "##### ",
+    "color": "#fe8019"
+  },
+  "h6": {
+    "prefix": "###### ",
+    "color": "#fb4934"
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "color": "#d3869b",
+    "italic": true
+  },
+  "strong": {
+    "color": "#fe8019",
+    "bold": true
+  },
+  "hr": {
+    "color": "#a89984",
+    "format": "\n--------\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "#83a598",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#83a598",
+    "bold": true
+  },
+  "image": {
+    "color": "#fe8019",
+    "underline": true
+  },
+  "image_text": {
+    "color": "#928374",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "#fb4934",
+    "background_color": "#3c3836"
+  },
+  "code_block": {
+    "color": "#ebdbb2",
+    "margin": 2,
+    "chroma": {
+      "text": {
+        "color": "#ebdbb2"
+      },
+      "error": {
+        "color": "#282828",
+        "background_color": "#fb4934"
+      },
+      "comment": {
+        "color": "#928374"
+      },
+      "comment_preproc": {
+        "color": "#fe8019"
+      },
+      "keyword": {
+        "color": "#83a598"
+      },
+      "keyword_reserved": {
+        "color": "#d3869b"
+      },
+      "keyword_namespace": {
+        "color": "#fb4934"
+      },
+      "keyword_type": {
+        "color": "#8ec07c"
+      },
+      "operator": {
+        "color": "#fb4934"
+      },
+      "punctuation": {
+        "color": "#fb4934"
+      },
+      "name": {},
+      "name_builtin": {
+        "color": "#83a598"
+      },
+      "name_tag": {
+        "color": "#8ec07c"
+      },
+      "name_attribute": {
+        "color": "#8ec07c"
+      },
+      "name_class": {
+        "color": "#ebdbb2",
+        "underline": true,
+        "bold": true
+      },
+      "name_constant": {
+        "color": "#8ec07c"
+      },
+      "name_decorator": {
+        "color": "#fabd2f"
+      },
+      "name_exception": {},
+      "name_function": {
+        "color": "#83a598"
+      },
+      "name_other": {},
+      "literal": {},
+      "literal_number": {
+        "color": "#fabd2f"
+      },
+      "literal_date": {},
+      "literal_string": {
+        "color": "#b8bb26"
+      },
+      "literal_string_escape": {
+        "color": "#8ec07c"
+      },
+      "generic_deleted": {
+        "color": "#fb4934"
+      },
+      "generic_emph": {
+        "italic": true
+      },
+      "generic_inserted": {
+        "color": "#b8bb26"
+      },
+      "generic_strong": {
+        "bold": true
+      },
+      "generic_subheading": {
+        "color": "#928374"
+      },
+      "background": {
+        "background_color": "#32302f"
+      }
+    }
+  },
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/styles/gruvbox-light.go
+++ b/styles/gruvbox-light.go
@@ -1,0 +1,229 @@
+package styles
+
+import "charm.land/glamour/v2/ansi"
+
+// GruvboxLightStyleConfig is the Gruvbox light style.
+var GruvboxLightStyleConfig = ansi.StyleConfig{
+	Document: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockPrefix: "\n",
+			BlockSuffix: "\n",
+			Color:       stringPtr("#282828"),
+		},
+		Margin: uintPtr(defaultMargin),
+	},
+	BlockQuote: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Color:  stringPtr("#b16286"),
+			Italic: boolPtr(true),
+		},
+		Indent:      uintPtr(2),
+		IndentToken: stringPtr("│ "),
+	},
+	List: ansi.StyleList{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color: stringPtr("#282828"),
+			},
+		},
+		LevelIndent: defaultListIndent,
+	},
+	Heading: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockSuffix: "\n",
+			Color:       stringPtr("#458588"),
+			Bold:        boolPtr(true),
+		},
+	},
+	H1: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "# ",
+			Color:  stringPtr("#458588"),
+			Bold:   boolPtr(true),
+		},
+	},
+	H2: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "## ",
+			Color:  stringPtr("#458588"),
+			Bold:   boolPtr(true),
+		},
+	},
+	H3: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "### ",
+			Color:  stringPtr("#689d6a"),
+			Bold:   boolPtr(true),
+		},
+	},
+	H4: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "#### ",
+			Color:  stringPtr("#d79921"),
+			Bold:   boolPtr(true),
+		},
+	},
+	H5: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "##### ",
+			Color:  stringPtr("#d65d0e"),
+		},
+	},
+	H6: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "###### ",
+			Color:  stringPtr("#cc241d"),
+		},
+	},
+	Strikethrough: ansi.StylePrimitive{
+		CrossedOut: boolPtr(true),
+	},
+	Emph: ansi.StylePrimitive{
+		Color:  stringPtr("#b16286"),
+		Italic: boolPtr(true),
+	},
+	Strong: ansi.StylePrimitive{
+		Color: stringPtr("#d65d0e"),
+		Bold:  boolPtr(true),
+	},
+	HorizontalRule: ansi.StylePrimitive{
+		Color:  stringPtr("#bdae93"),
+		Format: "\n--------\n",
+	},
+	Item: ansi.StylePrimitive{
+		BlockPrefix: "• ",
+	},
+	Enumeration: ansi.StylePrimitive{
+		BlockPrefix: ". ",
+	},
+	Task: ansi.StyleTask{
+		StylePrimitive: ansi.StylePrimitive{},
+		Ticked:         "[✓] ",
+		Unticked:       "[ ] ",
+	},
+	Link: ansi.StylePrimitive{
+		Color:     stringPtr("#458588"),
+		Underline: boolPtr(true),
+	},
+	LinkText: ansi.StylePrimitive{
+		Color: stringPtr("#458588"),
+		Bold:  boolPtr(true),
+	},
+	Image: ansi.StylePrimitive{
+		Color:     stringPtr("#d65d0e"),
+		Underline: boolPtr(true),
+	},
+	ImageText: ansi.StylePrimitive{
+		Color:  stringPtr("#928374"),
+		Format: "Image: {{.text}} →",
+	},
+	Code: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix:          " ",
+			Suffix:          " ",
+			Color:           stringPtr("#cc241d"),
+			BackgroundColor: stringPtr("#f2e5bc"),
+		},
+	},
+	CodeBlock: ansi.StyleCodeBlock{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color: stringPtr("#282828"),
+			},
+			Margin: uintPtr(defaultMargin),
+		},
+		Chroma: &ansi.Chroma{
+			Text: ansi.StylePrimitive{
+				Color: stringPtr("#282828"),
+			},
+			Error: ansi.StylePrimitive{
+				Color:           stringPtr("#fbf1c7"),
+				BackgroundColor: stringPtr("#cc241d"),
+			},
+			Comment: ansi.StylePrimitive{
+				Color: stringPtr("#928374"),
+			},
+			CommentPreproc: ansi.StylePrimitive{
+				Color: stringPtr("#d65d0e"),
+			},
+			Keyword: ansi.StylePrimitive{
+				Color: stringPtr("#458588"),
+			},
+			KeywordReserved: ansi.StylePrimitive{
+				Color: stringPtr("#b16286"),
+			},
+			KeywordNamespace: ansi.StylePrimitive{
+				Color: stringPtr("#cc241d"),
+			},
+			KeywordType: ansi.StylePrimitive{
+				Color: stringPtr("#689d6a"),
+			},
+			Operator: ansi.StylePrimitive{
+				Color: stringPtr("#cc241d"),
+			},
+			Punctuation: ansi.StylePrimitive{
+				Color: stringPtr("#cc241d"),
+			},
+			NameBuiltin: ansi.StylePrimitive{
+				Color: stringPtr("#458588"),
+			},
+			NameTag: ansi.StylePrimitive{
+				Color: stringPtr("#689d6a"),
+			},
+			NameAttribute: ansi.StylePrimitive{
+				Color: stringPtr("#689d6a"),
+			},
+			NameClass: ansi.StylePrimitive{
+				Color:     stringPtr("#282828"),
+				Underline: boolPtr(true),
+				Bold:      boolPtr(true),
+			},
+			NameConstant: ansi.StylePrimitive{
+				Color: stringPtr("#689d6a"),
+			},
+			NameDecorator: ansi.StylePrimitive{
+				Color: stringPtr("#d79921"),
+			},
+			NameFunction: ansi.StylePrimitive{
+				Color: stringPtr("#458588"),
+			},
+			LiteralNumber: ansi.StylePrimitive{
+				Color: stringPtr("#d79921"),
+			},
+			LiteralString: ansi.StylePrimitive{
+				Color: stringPtr("#98971a"),
+			},
+			LiteralStringEscape: ansi.StylePrimitive{
+				Color: stringPtr("#689d6a"),
+			},
+			GenericDeleted: ansi.StylePrimitive{
+				Color: stringPtr("#cc241d"),
+			},
+			GenericEmph: ansi.StylePrimitive{
+				Italic: boolPtr(true),
+			},
+			GenericInserted: ansi.StylePrimitive{
+				Color: stringPtr("#98971a"),
+			},
+			GenericStrong: ansi.StylePrimitive{
+				Bold: boolPtr(true),
+			},
+			GenericSubheading: ansi.StylePrimitive{
+				Color: stringPtr("#928374"),
+			},
+			Background: ansi.StylePrimitive{
+				BackgroundColor: stringPtr("#f2e5bc"),
+			},
+		},
+	},
+	Table: ansi.StyleTable{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{},
+		},
+	},
+	DefinitionDescription: ansi.StylePrimitive{
+		BlockPrefix: "\n🠶 ",
+	},
+	HTMLBlock: ansi.StyleBlock{},
+	HTMLSpan:  ansi.StyleBlock{},
+}

--- a/styles/gruvbox-light.json
+++ b/styles/gruvbox-light.json
@@ -1,0 +1,200 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "color": "#282828",
+    "margin": 2
+  },
+  "block_quote": {
+    "color": "#b16286",
+    "italic": true,
+    "indent": 2,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "color": "#282828",
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "#458588",
+    "bold": true
+  },
+  "h1": {
+    "prefix": "# ",
+    "color": "#458588",
+    "bold": true
+  },
+  "h2": {
+    "prefix": "## ",
+    "color": "#458588",
+    "bold": true
+  },
+  "h3": {
+    "prefix": "### ",
+    "color": "#689d6a",
+    "bold": true
+  },
+  "h4": {
+    "prefix": "#### ",
+    "color": "#d79921",
+    "bold": true
+  },
+  "h5": {
+    "prefix": "##### ",
+    "color": "#d65d0e"
+  },
+  "h6": {
+    "prefix": "###### ",
+    "color": "#cc241d"
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "color": "#b16286",
+    "italic": true
+  },
+  "strong": {
+    "color": "#d65d0e",
+    "bold": true
+  },
+  "hr": {
+    "color": "#bdae93",
+    "format": "\n--------\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "#458588",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#458588",
+    "bold": true
+  },
+  "image": {
+    "color": "#d65d0e",
+    "underline": true
+  },
+  "image_text": {
+    "color": "#928374",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "#cc241d",
+    "background_color": "#f2e5bc"
+  },
+  "code_block": {
+    "color": "#282828",
+    "margin": 2,
+    "chroma": {
+      "text": {
+        "color": "#282828"
+      },
+      "error": {
+        "color": "#fbf1c7",
+        "background_color": "#cc241d"
+      },
+      "comment": {
+        "color": "#928374"
+      },
+      "comment_preproc": {
+        "color": "#d65d0e"
+      },
+      "keyword": {
+        "color": "#458588"
+      },
+      "keyword_reserved": {
+        "color": "#b16286"
+      },
+      "keyword_namespace": {
+        "color": "#cc241d"
+      },
+      "keyword_type": {
+        "color": "#689d6a"
+      },
+      "operator": {
+        "color": "#cc241d"
+      },
+      "punctuation": {
+        "color": "#cc241d"
+      },
+      "name": {},
+      "name_builtin": {
+        "color": "#458588"
+      },
+      "name_tag": {
+        "color": "#689d6a"
+      },
+      "name_attribute": {
+        "color": "#689d6a"
+      },
+      "name_class": {
+        "color": "#282828",
+        "underline": true,
+        "bold": true
+      },
+      "name_constant": {
+        "color": "#689d6a"
+      },
+      "name_decorator": {
+        "color": "#d79921"
+      },
+      "name_exception": {},
+      "name_function": {
+        "color": "#458588"
+      },
+      "name_other": {},
+      "literal": {},
+      "literal_number": {
+        "color": "#d79921"
+      },
+      "literal_date": {},
+      "literal_string": {
+        "color": "#98971a"
+      },
+      "literal_string_escape": {
+        "color": "#689d6a"
+      },
+      "generic_deleted": {
+        "color": "#cc241d"
+      },
+      "generic_emph": {
+        "italic": true
+      },
+      "generic_inserted": {
+        "color": "#98971a"
+      },
+      "generic_strong": {
+        "bold": true
+      },
+      "generic_subheading": {
+        "color": "#928374"
+      },
+      "background": {
+        "background_color": "#f2e5bc"
+      }
+    }
+  },
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/styles/styles.go
+++ b/styles/styles.go
@@ -15,13 +15,15 @@ const (
 
 // Default styles.
 const (
-	AsciiStyle      = "ascii" //nolint: revive
-	DarkStyle       = "dark"
-	DraculaStyle    = "dracula"
-	TokyoNightStyle = "tokyo-night"
-	LightStyle      = "light"
-	NoTTYStyle      = "notty"
-	PinkStyle       = "pink"
+	AsciiStyle        = "ascii" //nolint: revive
+	DarkStyle         = "dark"
+	DraculaStyle      = "dracula"
+	GruvboxDarkStyle  = "gruvbox-dark"
+	GruvboxLightStyle = "gruvbox-light"
+	TokyoNightStyle   = "tokyo-night"
+	LightStyle        = "light"
+	NoTTYStyle        = "notty"
+	PinkStyle         = "pink"
 )
 
 var (
@@ -670,8 +672,10 @@ var (
 		PinkStyle:  &PinkStyleConfig,
 
 		// Popular themes
-		DraculaStyle:    &DraculaStyleConfig,
-		TokyoNightStyle: &TokyoNightStyleConfig,
+		DraculaStyle:      &DraculaStyleConfig,
+		GruvboxDarkStyle:  &GruvboxDarkStyleConfig,
+		GruvboxLightStyle: &GruvboxLightStyleConfig,
+		TokyoNightStyle:   &TokyoNightStyleConfig,
 	}
 )
 


### PR DESCRIPTION
I am just a user of the theme---I am not related to the authors. ;)

Refs for gruvbox
----------------

> gruvbox is heavily inspired by badwolf, jellybeans and solarized.

> Designed as a bright theme with pastel 'retro groove' colors and
light/dark mode switching in the way of solarized. The main focus when developing gruvbox is to keep colors easily distinguishable, contrast enough and still pleasant for the eyes.

 * https://github.com/morhetz/gruvbox
 * https://github.com/morhetz/gruvbox-contrib

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

---

There is already a feature request for gruvbox: #168. My version is a little bit different. I'm obviously open to change and feedback.
