### PR TITLE
fix(ansi): honor Conceal in renderText

### DIFF
--- a/ansi/baseelement.go
+++ b/ansi/baseelement.go
@@ -41,6 +41,13 @@ func renderText(w io.Writer, rules StylePrimitive, s string) (int, error) { //no
 		return 0, nil
 	}
 
+	// Conceal hides the text entirely. It was parsed by [StylePrimitive] but
+	// never applied during rendering, so styles asking to conceal links (or
+	// anything else) were silently ignored. See charmbracelet/glamour#121.
+	if rules.Conceal != nil && *rules.Conceal {
+		return 0, nil
+	}
+
 	// XXX: We're using [ansi.Style] instead of [lipgloss.Style] because
 	// Lip Gloss has a weird bug where it adds spaces when rendering joined
 	// strings. Needs further investigation.

--- a/ansi/baseelement_test.go
+++ b/ansi/baseelement_test.go
@@ -1,0 +1,50 @@
+package ansi
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRenderTextConceal(t *testing.T) {
+	// Regression test for https://github.com/charmbracelet/glamour/issues/121
+	// and https://github.com/charmbracelet/glow/issues/645. Setting
+	// "conceal": true on a style primitive must actually hide the rendered
+	// text, not just be parsed into the struct and dropped.
+	conceal := true
+
+	tests := []struct {
+		name  string
+		rules StylePrimitive
+		input string
+		want  string
+	}{
+		{
+			name:  "conceal true hides text",
+			rules: StylePrimitive{Conceal: &conceal},
+			input: "https://example.com",
+			want:  "",
+		},
+		{
+			name:  "conceal nil renders normally",
+			rules: StylePrimitive{},
+			input: "https://example.com",
+			want:  "https://example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			n, err := renderText(&buf, tt.rules, tt.input)
+			if err != nil {
+				t.Fatalf("renderText returned error: %v", err)
+			}
+			if buf.String() != tt.want {
+				t.Errorf("renderText output: got %q, want %q", buf.String(), tt.want)
+			}
+			if n != len(tt.want) {
+				t.Errorf("renderText byte count: got %d, want %d", n, len(tt.want))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #121, addresses charmbracelet/glow#645.

\`StylePrimitive.Conceal\` has been on the struct since forever (parsed from style JSON, propagated through \`cascadeStyle\`), but \`renderText\` in \`ansi/baseelement.go\` never actually consulted it, so setting \`\"conceal\": true\` on \`link\` (or anything else) silently rendered the text anyway.

One-line fix: short-circuit \`renderText\` when \`Conceal\` is true.

## Test plan

\`\`\`
go test ./...
\`\`\`

Added \`TestRenderTextConceal\` covering both the conceal-true (output is empty) and conceal-nil (renders normally) paths. Existing golden tests still pass.