### PR TITLE
fix(ansi): handle all CommonMark backslash escapes

### DIFF
--- a/ansi/baseelement.go
+++ b/ansi/baseelement.go
@@ -134,24 +134,43 @@ func (e *BaseElement) doRender(w io.Writer, st1, st2 StylePrimitive) error {
 	return nil
 }
 
-// https://www.markdownguide.org/basic-syntax/#characters-you-can-escape
+// escapeReplacer strips a leading backslash from any backslash-escaped ASCII
+// punctuation character, per the CommonMark spec
+// (https://spec.commonmark.org/current/#backslash-escapes), which says "any
+// ASCII punctuation character may be backslash-escaped". The previous list
+// was missing several characters, notably `~`, which meant `\~` rendered as
+// `\~` instead of `~`. See charmbracelet/glamour#503.
 var escapeReplacer = strings.NewReplacer(
-	"\\\\", "\\",
-	"\\`", "`",
-	"\\*", "*",
-	"\\_", "_",
-	"\\{", "{",
-	"\\}", "}",
-	"\\[", "[",
-	"\\]", "]",
-	"\\<", "<",
-	"\\>", ">",
+	`\\`, `\`,
+	"\\!", "!",
+	`\"`, `"`,
+	"\\#", "#",
+	`\$`, `$`,
+	`\%`, `%`,
+	`\&`, `&`,
+	`\'`, `'`,
 	"\\(", "(",
 	"\\)", ")",
-	"\\#", "#",
+	"\\*", "*",
 	"\\+", "+",
+	`\,`, `,`,
 	"\\-", "-",
 	"\\.", ".",
-	"\\!", "!",
+	`\/`, `/`,
+	`\:`, `:`,
+	`\;`, `;`,
+	"\\<", "<",
+	`\=`, `=`,
+	"\\>", ">",
+	`\?`, `?`,
+	`\@`, `@`,
+	"\\[", "[",
+	"\\]", "]",
+	`\^`, `^`,
+	"\\_", "_",
+	"\\`", "`",
+	"\\{", "{",
 	"\\|", "|",
+	"\\}", "}",
+	`\~`, `~`,
 )

--- a/ansi/baseelement_test.go
+++ b/ansi/baseelement_test.go
@@ -1,0 +1,59 @@
+package ansi
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRenderTextEscapeReplacer(t *testing.T) {
+	// Regression test for https://github.com/charmbracelet/glamour/issues/503.
+	// Any ASCII punctuation backslash-escape should be stripped, per the
+	// CommonMark spec. Previously only a subset was handled, so `\~`, `\?`,
+	// `\@` etc. rendered verbatim.
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "backslash", in: `\\`, want: `\`},
+		{name: "tilde was missing", in: `\~`, want: `~`},
+		{name: "question mark was missing", in: `\?`, want: `?`},
+		{name: "at sign was missing", in: `\@`, want: `@`},
+		{name: "caret was missing", in: `\^`, want: `^`},
+		{name: "double quote was missing", in: `\"`, want: `"`},
+		{name: "ampersand was missing", in: `\&`, want: `&`},
+		{name: "equals was missing", in: `\=`, want: `=`},
+		{name: "slash was missing", in: `\/`, want: `/`},
+		{name: "colon was missing", in: `\:`, want: `:`},
+		{name: "semicolon was missing", in: `\;`, want: `;`},
+		{name: "asterisk still works", in: `\*`, want: `*`},
+		{name: "underscore still works", in: `\_`, want: `_`},
+		{name: "tilde inside a word", in: `foo\~bar`, want: `foo~bar`},
+		{name: "double-escaped tilde keeps the backslash", in: `\\\~`, want: `\~`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := escapeReplacer.Replace(tt.in)
+			if got != tt.want {
+				t.Errorf("escapeReplacer.Replace(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderText_EscapesPropagateThroughRender(t *testing.T) {
+	// Sanity check that doRender actually feeds the token through
+	// escapeReplacer, so the fix is visible in the rendered output and not
+	// just in the replacer itself.
+	var buf bytes.Buffer
+	e := &BaseElement{Token: `hello \~ world`}
+	if err := e.doRender(&buf, StylePrimitive{}, StylePrimitive{}); err != nil {
+		t.Fatalf("doRender returned error: %v", err)
+	}
+	got := buf.String()
+	want := "hello ~ world"
+	if got != want {
+		t.Errorf("doRender output: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #503.

\`escapeReplacer\` in \`ansi/baseelement.go\` only covered a subset of ASCII punctuation, so things like \`\\~\`, \`\\?\`, \`\\@\`, \`\\^\`, \`\\\"\`, \`\\&\`, \`\\=\`, \`\\/\`, \`\\:\` etc. rendered verbatim instead of having the backslash stripped. The CommonMark spec (\"any ASCII punctuation character may be backslash-escaped\") makes the fix easy: list the full set.

The reported case from #503:

| Input | Before | After (expected) |
|---|---|---|
| \`\\~\` | \`\\~\` | \`~\` |
| \`\\~foo\\~\` | \`\\~foo\\~\` | \`~foo~\` |
| \`\\\\\\~foo\\\\\\~\` | \`\\\\~foo\\\\~\` | \`\\~foo\\~\` |

(All three now match the \"After\" column.)

## Test plan

\`\`\`
go test ./...
\`\`\`

Added two unit tests: \`TestRenderTextEscapeReplacer\` covering every previously-missing character plus a few that already worked, and \`TestRenderText_EscapesPropagateThroughRender\` so a future refactor doesn't silently disconnect the replacer from the render path. Existing golden tests still pass.