### PR TITLE
fix: preserve HTML entities in inline code spans

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -366,7 +366,7 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		s := string(n.Text(source)) //nolint: staticcheck
 		return Element{
 			Renderer: &CodeSpanElement{
-				Text:  html.UnescapeString(s),
+				Text:  s,
 				Style: cascadeStyle(ctx.blockStack.Current().Style, ctx.options.Styles.Code, false).StylePrimitive,
 			},
 		}

--- a/glamour_test.go
+++ b/glamour_test.go
@@ -302,6 +302,24 @@ func TestWithChromaFormatterDefault(t *testing.T) {
 	golden.RequireEqual(t, []byte(b))
 }
 
+func TestCodeSpanPreservesHTMLEntities(t *testing.T) {
+	r, err := NewTermRenderer(
+		WithStandardStyle("dark"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := r.Render("`>` has to be escaped like `&gt;`.")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(out, "&gt;") {
+		t.Fatalf("expected literal &gt; in codespan output, got %q", out)
+	}
+}
+
 func TestWithChromaFormatterCustom(t *testing.T) {
 	r, err := NewTermRenderer(
 		WithStandardStyle(styles.DarkStyle),


### PR DESCRIPTION
## Summary

Fixes #94.

Inline code spans now render markdown source verbatim. HTML entities such as `&gt;` are no longer unescaped during codespan rendering.

## Test plan

- [x] `go test -run TestCodeSpanPreservesHTMLEntities -v`