### PR TITLE
fix(ansi): honor the conceal style primitive

### DIFF
--- a/ansi/baseelement.go
+++ b/ansi/baseelement.go
@@ -40,6 +40,9 @@ func renderText(w io.Writer, rules StylePrimitive, s string) (int, error) { //no
 	if len(s) == 0 {
 		return 0, nil
 	}
+	if rules.Conceal != nil && *rules.Conceal {
+		return 0, nil
+	}
 
 	// XXX: We're using [ansi.Style] instead of [lipgloss.Style] because
 	// Lip Gloss has a weird bug where it adds spaces when rendering joined

--- a/ansi/conceal_test.go
+++ b/ansi/conceal_test.go
@@ -1,0 +1,33 @@
+package ansi
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRenderText_ConcealHidesOutput(t *testing.T) {
+	conceal := true
+	rules := StylePrimitive{Conceal: &conceal}
+
+	var buf bytes.Buffer
+	n, err := renderText(&buf, rules, "hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 || buf.Len() != 0 {
+		t.Errorf("expected concealed output to be empty, got %q (n=%d)", buf.String(), n)
+	}
+}
+
+func TestRenderText_ConcealFalseStillRenders(t *testing.T) {
+	conceal := false
+	rules := StylePrimitive{Conceal: &conceal}
+
+	var buf bytes.Buffer
+	if _, err := renderText(&buf, rules, "hello"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("hello")) {
+		t.Errorf("expected output to contain %q, got %q", "hello", buf.String())
+	}
+}


### PR DESCRIPTION
Filed in charmbracelet/glow#645. `StylePrimitive.Conceal` is exposed in the JSON style schema and the cascade picks it up correctly, but `renderText` never consulted it. So setting `"conceal": true` on the `link` element in a custom style had no effect — the URL still rendered.

The fix is to short-circuit `renderText` when `Conceal` is true.

Added a small unit test that exercises both the conceal-true and conceal-false branches.

Closes charmbracelet/glow#645