### PR TITLE
fix: improveIndentWriter.Close to handle errors correctly

### DIFF
--- a/ansi/margin.go
+++ b/ansi/margin.go
@@ -217,10 +217,10 @@ func (w *IndentWriter) Write(p []byte) (int, error) {
 
 // Close closes the [IndentWriter].
 func (w *IndentWriter) Close() error {
-	var werr error
-	if w, ok := w.w.(io.WriteCloser); ok {
-		werr = w.Close()
+	werr := w.pw.Close()
+	var cerr error
+	if c, ok := w.w.(io.WriteCloser); ok {
+		cerr = c.Close()
 	}
-
-	return errors.Join(werr, w.pw.Close())
+	return errors.Join(werr, cerr)
 }


### PR DESCRIPTION
I surfaced this testing Crush.  Combined with [lipgloss #689](https://github.com/charmbracelet/lipgloss/pull/689) this can segfault Crush.

LLM-assisted, but I read and understood it all.

----

Order matters: `w.pw` wraps `w.w` (a *PaddingWriter whose own writer is itself a [lipgloss.WrapWriter]). Closing the `WrapWriter w.pw` can flush a trailing `ResetStyle / ResetHyperlink` into `w.w`; if we closed `w.w` first, that PaddingWriter would forward the resets into an already-closed inner `WrapWriter` whose `ansi.Parser` has been returned to the pool — a nil-pointer dereference in `Parser.Advance`.

So: drain the upstream writer first, *then* close the downstream one.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
