### PR TITLE
fix: make style/theme names case-insensitive

### DIFF
--- a/glamour.go
+++ b/glamour.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/yuin/goldmark"
 	emoji "github.com/yuin/goldmark-emoji"
@@ -286,7 +287,7 @@ func getEnvironmentStyle() string {
 }
 
 func getDefaultStyle(style string) (*ansi.StyleConfig, error) {
-	styles, ok := styles.DefaultStyles[style]
+	styles, ok := styles.DefaultStyles[strings.ToLower(style)]
 	if !ok {
 		return nil, fmt.Errorf("%s: style not found", style)
 	}

--- a/glamour_test.go
+++ b/glamour_test.go
@@ -323,3 +323,73 @@ func TestWithChromaFormatterCustom(t *testing.T) {
 
 	golden.RequireEqual(t, []byte(b))
 }
+
+func TestCaseInsensitiveStyleName(t *testing.T) {
+	// Test that style names are case-insensitive (issue #323)
+	cases := []struct {
+		name  string
+		style string
+	}{
+		{"lowercase", "dark"},
+		{"uppercase", "DARK"},
+		{"mixed case", "Dark"},
+		{"title case", "Dracula"},
+		{"kebab lowercase", "tokyo-night"},
+		{"kebab uppercase", "TOKYO-NIGHT"},
+		{"kebab mixed", "Tokyo-Night"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := NewTermRenderer(
+				WithStandardStyle(tc.style),
+			)
+			if err != nil {
+				t.Fatalf("WithStandardStyle(%q) returned error: %v", tc.style, err)
+			}
+
+			in, err := os.ReadFile(markdown)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = r.Render(string(in))
+			if err != nil {
+				t.Fatalf("Render with style %q returned error: %v", tc.style, err)
+			}
+		})
+	}
+}
+
+func TestCaseInsensitiveStylePath(t *testing.T) {
+	// Test that WithStylePath also handles case-insensitive style names
+	cases := []struct {
+		name     string
+		styleArg string
+	}{
+		{"lowercase", "dark"},
+		{"uppercase", "DARK"},
+		{"mixed case", "Light"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := NewTermRenderer(
+				WithStylePath(tc.styleArg),
+			)
+			if err != nil {
+				t.Fatalf("WithStylePath(%q) returned error: %v", tc.styleArg, err)
+			}
+
+			in, err := os.ReadFile(markdown)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = r.Render(string(in))
+			if err != nil {
+				t.Fatalf("Render with style %q returned error: %v", tc.styleArg, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Style names like `Dark`, `DARK`, `Tokyo-Night` now resolve correctly instead of returning `style not found`. The lookup in `getDefaultStyle` normalizes the input to lowercase before matching against `DefaultStyles`.

This means users can now use any casing when specifying built-in themes:
- `WithStandardStyle("Dark")` ✅ (previously failed)
- `WithStylePath("TOKYO-NIGHT")` ✅ (previously failed)
- `GLAMOUR_STYLE=Dracula` ✅ (previously failed)

Fixes #323

### Changes
- `glamour.go`: Added `strings.ToLower()` to `getDefaultStyle()` lookup
- `glamour_test.go`: Added `TestCaseInsensitiveStyleName` and `TestCaseInsensitiveStylePath` covering various casing patterns (lowercase, uppercase, mixed case, kebab-case variants)