### PR TITLE
feat(table): add configurable table border toggles

### DIFF
--- a/ansi/style.go
+++ b/ansi/style.go
@@ -91,6 +91,21 @@ type StyleTable struct {
 	CenterSeparator *string `json:"center_separator,omitempty"`
 	ColumnSeparator *string `json:"column_separator,omitempty"`
 	RowSeparator    *string `json:"row_separator,omitempty"`
+
+	// Border visibility toggles. These control which borders are drawn,
+	// independently of the separator characters above. When a field is nil,
+	// glamour's historical default applies: the header rule and the column
+	// separators are drawn, while the outer frame and the inter-row dividers
+	// are not. Set any field to override a single edge — e.g. RowBorder to
+	// true draws a divider between every row, or the four frame fields to
+	// true to box the table in.
+	HeaderBorder *bool `json:"header_border,omitempty"`
+	RowBorder    *bool `json:"row_border,omitempty"`
+	ColumnBorder *bool `json:"column_border,omitempty"`
+	TopBorder    *bool `json:"top_border,omitempty"`
+	BottomBorder *bool `json:"bottom_border,omitempty"`
+	LeftBorder   *bool `json:"left_border,omitempty"`
+	RightBorder  *bool `json:"right_border,omitempty"`
 }
 
 // StyleConfig is used to configure the styling behavior of an ANSIRenderer.

--- a/ansi/table.go
+++ b/ansi/table.go
@@ -117,10 +117,28 @@ func (e *TableElement) setBorders(ctx RenderContext) {
 		}
 	}
 	ctx.table.lipgloss.Border(border)
-	ctx.table.lipgloss.BorderTop(false)
-	ctx.table.lipgloss.BorderLeft(false)
-	ctx.table.lipgloss.BorderRight(false)
-	ctx.table.lipgloss.BorderBottom(false)
+
+	// Border visibility. The defaults reproduce glamour's historical table
+	// look — header rule and column separators on, outer frame and inter-row
+	// dividers off — so styles that do not set the toggles render unchanged.
+	// Each edge can be overridden through StyleTable, e.g. RowBorder enables a
+	// divider between every row, or the four frame toggles box the table in.
+	ctx.table.lipgloss.BorderTop(borderEnabled(rules.TopBorder, false))
+	ctx.table.lipgloss.BorderBottom(borderEnabled(rules.BottomBorder, false))
+	ctx.table.lipgloss.BorderLeft(borderEnabled(rules.LeftBorder, false))
+	ctx.table.lipgloss.BorderRight(borderEnabled(rules.RightBorder, false))
+	ctx.table.lipgloss.BorderHeader(borderEnabled(rules.HeaderBorder, true))
+	ctx.table.lipgloss.BorderColumn(borderEnabled(rules.ColumnBorder, true))
+	ctx.table.lipgloss.BorderRow(borderEnabled(rules.RowBorder, false))
+}
+
+// borderEnabled resolves an optional table border toggle, falling back to
+// glamour's default when the style leaves it unset.
+func borderEnabled(toggle *bool, fallback bool) bool {
+	if toggle != nil {
+		return *toggle
+	}
+	return fallback
 }
 
 // Finish finishes rendering a TableElement.

--- a/styles/README.md
+++ b/styles/README.md
@@ -225,6 +225,27 @@ Output:
 
 ![Table Example](https://github.com/charmbracelet/glamour/raw/master/styles/examples/table.png)
 
+#### Borders
+
+By default a table draws the header rule and the column separators only. Each
+border can be toggled independently — for example, to draw a divider between
+every row, or to box the whole table in:
+
+```json
+"table": {
+    "row_border": true,
+    "top_border": true,
+    "bottom_border": true,
+    "left_border": true,
+    "right_border": true
+}
+```
+
+The available toggles are `header_border`, `row_border`, `column_border`,
+`top_border`, `bottom_border`, `left_border` and `right_border`. When a toggle
+is omitted it keeps glamour's default (`header_border` and `column_border` on;
+the rest off).
+
 ## Inline Elements
 
 All inline elements support the following style settings:

--- a/table_border_test.go
+++ b/table_border_test.go
@@ -1,0 +1,96 @@
+package glamour
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"charm.land/glamour/v2/ansi"
+	"charm.land/glamour/v2/styles"
+)
+
+const tableBorderMarkdown = `
+| Header A  | Header B  |
+| --------- | --------- |
+| Cell 1    | Cell 2    |
+| Cell 3    | Cell 4    |
+`
+
+// separatorLines counts the horizontal rule lines in a rendered table: lines
+// made up solely of border runes (dashes, column/cross separators, spaces)
+// that contain at least one dash.
+func separatorLines(rendered string) int {
+	n := 0
+	for _, line := range strings.Split(rendered, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.ContainsRune(trimmed, '-') && strings.Trim(trimmed, "-+|─┼ ") == "" {
+			n++
+		}
+	}
+	return n
+}
+
+func renderTable(t *testing.T, mutate func(*ansi.StyleConfig)) string {
+	t.Helper()
+	style := styles.ASCIIStyleConfig
+	if mutate != nil {
+		mutate(&style)
+	}
+	renderer, err := NewTermRenderer(WithStyles(style), WithWordWrap(80))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := renderer.Render(strings.TrimSpace(tableBorderMarkdown))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// TestTableDefaultHasNoRowBorder pins the historical default: a table renders
+// only the header rule, with no divider between body rows.
+func TestTableDefaultHasNoRowBorder(t *testing.T) {
+	if got := separatorLines(renderTable(t, nil)); got != 1 {
+		t.Errorf("default table want 1 separator line (header rule only), got %d", got)
+	}
+}
+
+// TestTableRowBorderDrawsDividers verifies RowBorder=true adds a divider
+// between every pair of body rows on top of the header rule.
+func TestTableRowBorderDrawsDividers(t *testing.T) {
+	out := renderTable(t, func(c *ansi.StyleConfig) {
+		v := true
+		c.Table.RowBorder = &v
+	})
+	// header rule + one divider between the two body rows.
+	if got := separatorLines(out); got != 2 {
+		t.Errorf("RowBorder table want 2 separator lines, got %d:\n%s", got, out)
+	}
+}
+
+func ExampleStyleTable_rowBorder() {
+	style := styles.ASCIIStyleConfig
+	rowBorder := true
+	style.Table.RowBorder = &rowBorder
+
+	renderer, err := NewTermRenderer(WithStyles(style), WithWordWrap(80))
+	if err != nil {
+		return
+	}
+	result, err := renderer.Render(strings.TrimSpace(tableBorderMarkdown))
+	if err != nil {
+		return
+	}
+	fmt.Println(strings.ReplaceAll(result, " ", "."))
+
+	// Output:
+	// ..............................................................................
+	// ...Header.A.............................|.Header.B............................
+	// ..--------------------------------------|-------------------------------------
+	// ...Cell.1...............................|.Cell.2..............................
+	// ..--------------------------------------|-------------------------------------
+	// ...Cell.3...............................|.Cell.4..............................
+}


### PR DESCRIPTION
Closes #563.

### What

Adds seven optional `*bool` toggles to `ansi.StyleTable` — `HeaderBorder`, `RowBorder`, `ColumnBorder`, `TopBorder`, `BottomBorder`, `LeftBorder`, `RightBorder` (JSON: `header_border`, `row_border`, …) — mapping onto the corresponding lipgloss table border switches. `setBorders` now honors them.

### Why

Border visibility was hardcoded in `setBorders`, so a style could pick separator *characters* but not whether row dividers or an outer frame were drawn. There was no way to render a horizontal divider between table rows. See #563.

### Backward compatibility

Each toggle is a pointer; an unset field keeps glamour's historical default — header rule and column separators on, outer frame and inter-row dividers off. Styles that don't set the fields render byte-for-byte as before, so the existing golden tests pass unchanged.

### Tests / docs

Adds tests pinning the default (one separator line) and `RowBorder` (a divider between body rows), a runnable `Example`, and documents the toggles in `styles/README.md`.

Example (`row_border: true`, ASCII style):

```
 #  | Quyết định      | ...
----+-----------------+----
 D1 | ...             | ...
----+-----------------+----
 D2 | ...             | ...
```