### PR TITLE
fix: unescape all ASCII punctuation in escapeReplacer

### DIFF
--- a/ansi/baseelement.go
+++ b/ansi/baseelement.go
@@ -134,24 +134,42 @@ func (e *BaseElement) doRender(w io.Writer, st1, st2 StylePrimitive) error {
 	return nil
 }
 
-// https://www.markdownguide.org/basic-syntax/#characters-you-can-escape
+// escapeReplacer strips the backslash from backslash-escaped ASCII punctuation.
+// CommonMark allows any ASCII punctuation character to be escaped, so every
+// such character is listed here (the previous list followed markdownguide.org
+// and was missing several, e.g. `\~`; see issue #503).
+// https://spec.commonmark.org/0.31.2/#backslash-escapes
 var escapeReplacer = strings.NewReplacer(
 	"\\\\", "\\",
-	"\\`", "`",
-	"\\*", "*",
-	"\\_", "_",
-	"\\{", "{",
-	"\\}", "}",
-	"\\[", "[",
-	"\\]", "]",
-	"\\<", "<",
-	"\\>", ">",
+	"\\!", "!",
+	"\\\"", "\"",
+	"\\#", "#",
+	"\\$", "$",
+	"\\%", "%",
+	"\\&", "&",
+	"\\'", "'",
 	"\\(", "(",
 	"\\)", ")",
-	"\\#", "#",
+	"\\*", "*",
 	"\\+", "+",
+	"\\,", ",",
 	"\\-", "-",
 	"\\.", ".",
-	"\\!", "!",
+	"\\/", "/",
+	"\\:", ":",
+	"\\;", ";",
+	"\\<", "<",
+	"\\=", "=",
+	"\\>", ">",
+	"\\?", "?",
+	"\\@", "@",
+	"\\[", "[",
+	"\\]", "]",
+	"\\^", "^",
+	"\\_", "_",
+	"\\`", "`",
+	"\\{", "{",
 	"\\|", "|",
+	"\\}", "}",
+	"\\~", "~",
 )

--- a/ansi/renderer_test.go
+++ b/ansi/renderer_test.go
@@ -144,3 +144,33 @@ func TestRendererIssues(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeReplacer(t *testing.T) {
+	// Any ASCII punctuation character may be backslash-escaped in CommonMark,
+	// and glamour must strip the backslash for all of them. The previous list
+	// was missing several; \~ (issue #503) is the most visible since ~ is used
+	// for strikethrough.
+	cases := map[string]string{
+		`\~`: `~`,
+		`\"`: `"`,
+		`\$`: `$`,
+		`\%`: `%`,
+		`\&`: `&`,
+		`\'`: `'`,
+		`\,`: `,`,
+		`\/`: `/`,
+		`\:`: `:`,
+		`\;`: `;`,
+		`\=`: `=`,
+		`\?`: `?`,
+		`\@`: `@`,
+		`\^`: `^`,
+		`\*`: `*`, // already worked; guards against regression
+		`\\`: `\`,
+	}
+	for in, want := range cases {
+		if got := escapeReplacer.Replace(in); got != want {
+			t.Errorf("escapeReplacer.Replace(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #503.

glamour does its own backslash-unescaping in `escapeReplacer` (`ansi/baseelement.go`) instead of going through goldmark's HTML writer. That replacer was built from the [markdownguide.org](https://www.markdownguide.org/basic-syntax/#characters-you-can-escape) list and is missing several characters that CommonMark allows to be escaped, so the backslash is left in the rendered output for:

```
\~  \"  \$  \%  \&  \'  \,  \/  \:  \;  \=  \?  \@  \^
```

`\~` is the one reported in #503 and is the most visible, since `~` is used for strikethrough — `\~foo\~` rendered as `\~foo\~` instead of `~foo~`.

Per the [CommonMark spec](https://spec.commonmark.org/0.31.2/#backslash-escapes), a backslash before *any* ASCII punctuation character is an escape, so `escapeReplacer` now lists all of them.

Added `TestEscapeReplacer` in `ansi/renderer_test.go` covering the previously-missing characters plus a couple that already worked, to guard against regressions. `go test ./ansi/...` passes and the existing golden tests are unchanged.
