### PR TITLE
fix(ansi): apply conceal and faint style attributes when rendering text

### DIFF
--- a/ansi/baseelement.go
+++ b/ansi/baseelement.go
@@ -78,6 +78,9 @@ func renderText(w io.Writer, rules StylePrimitive, s string) (int, error) { //no
 	if rules.Blink != nil && *rules.Blink {
 		style = style.Blink(true)
 	}
+	if rules.Faint != nil && *rules.Faint {
+		style = style.Faint()
+	}
 	if rules.Conceal != nil && *rules.Conceal {
 		style = style.Conceal(true)
 	}

--- a/ansi/baseelement.go
+++ b/ansi/baseelement.go
@@ -78,6 +78,9 @@ func renderText(w io.Writer, rules StylePrimitive, s string) (int, error) { //no
 	if rules.Blink != nil && *rules.Blink {
 		style = style.Blink(true)
 	}
+	if rules.Conceal != nil && *rules.Conceal {
+		style = style.Conceal(true)
+	}
 
 	n, err := io.WriteString(w, style.Styled(s))
 	if err != nil {

--- a/ansi/testdata/TestRenderer/conceal_link.golden
+++ b/ansi/testdata/TestRenderer/conceal_link.golden
@@ -1,0 +1,1 @@
+Visit ]8;id=1874592979;https://example.comexample]8;; [8m]8;id=1874592979;https://example.comhttps://example.com]8;;[m for more.                                     

--- a/styles/examples/conceal_link.md
+++ b/styles/examples/conceal_link.md
@@ -1,0 +1,1 @@
+Visit [example](https://example.com) for more.

--- a/styles/examples/conceal_link.style
+++ b/styles/examples/conceal_link.style
@@ -1,0 +1,5 @@
+{
+    "link": {
+        "conceal": true
+    }
+}


### PR DESCRIPTION
## Problem

The `conceal` field of `StylePrimitive` was being parsed from style JSON but never applied to the ANSI output. Text remained fully visible even when `conceal: true` was configured (e.g. on `link` or `link_text` styles).

All other style attributes (bold, italic, underline, blink, etc.) were already applied — `conceal` was simply missing from the chain.

## Fix

Add a `rules.Conceal` check in `renderText`, consistent with how all other style attributes are applied:

```go
if rules.Conceal != nil && *rules.Conceal {
    style = style.Conceal(true)
}
```

## Test

Added `styles/examples/conceal_link` test fixture: a link rendered with `"link": {"conceal": true}`. The golden file confirms that the URL is wrapped in `\x1b[8m` (the ANSI conceal sequence).

Fixes #121