### PR TITLE
Add nord theme

### DIFF
--- a/UPGRADE_GUIDE_V2.md
+++ b/UPGRADE_GUIDE_V2.md
@@ -50,7 +50,7 @@ r, _ := glamour.NewTermRenderer(glamour.WithStylePath("light"))
 // For dark backgrounds (default)
 r, _ := glamour.NewTermRenderer(glamour.WithStylePath("dark"))
 
-// Other built-in styles: "pink", "dracula", "tokyo-night", "ascii"
+// Other built-in styles: "pink", "dracula", "nord", "tokyo-night", "ascii"
 r, _ := glamour.NewTermRenderer(glamour.WithStylePath("dracula"))
 ```
 

--- a/gallery.sh
+++ b/gallery.sh
@@ -6,7 +6,7 @@ if ! command -v freeze &> /dev/null; then
     exit 1
 fi
 
-defaultStyles=("ascii" "auto" "dark" "dracula" "light" "notty" "pink")
+defaultStyles=("ascii" "auto" "dark" "dracula" "light" "nord" "notty" "pink" "tokyo-night")
 
 for style in "${defaultStyles[@]}"; do
     echo "Generating screenshot for ${style}"

--- a/styles/gallery/README.md
+++ b/styles/gallery/README.md
@@ -18,6 +18,10 @@ Pronounced _naughty_.
 
 ![Dracula Style](./dracula.png)
 
+## Nord
+
+![Nord Style](./nord.png)
+
 ## Tokyo Night
 
 ![Tokyo Night Style](./tokyo-night.png)

--- a/styles/gallery/nord.png
+++ b/styles/gallery/nord.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:939f0ad2618fec54884e0d5d3568366844800bd6c78b94f4566a126ff5735526
+size 743840

--- a/styles/nord.go
+++ b/styles/nord.go
@@ -1,0 +1,217 @@
+package styles
+
+import "charm.land/glamour/v2/ansi"
+
+// NordStyleConfig is the nord style.
+var NordStyleConfig = ansi.StyleConfig{
+	Document: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockPrefix: "\n",
+			BlockSuffix: "\n",
+			Color:       stringPtr("#d8dee9"),
+		},
+		Margin: uintPtr(defaultMargin),
+	},
+	BlockQuote: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Color: stringPtr("#8B95A7"),
+		},
+		Indent:      uintPtr(1),
+		IndentToken: stringPtr("│ "),
+	},
+	List: ansi.StyleList{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color: stringPtr("#d8dee9"),
+			},
+		},
+		LevelIndent: defaultListIndent,
+	},
+	Heading: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockSuffix: "\n",
+			Color:       stringPtr("#88c0d0"),
+			Bold:        boolPtr(true),
+		},
+	},
+	H1: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "# ",
+		},
+	},
+	H2: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "## ",
+		},
+	},
+	H3: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "### ",
+		},
+	},
+	H4: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "#### ",
+		},
+	},
+	H5: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "##### ",
+		},
+	},
+	H6: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "###### ",
+		},
+	},
+	Strikethrough: ansi.StylePrimitive{
+		CrossedOut: boolPtr(true),
+	},
+	Emph: ansi.StylePrimitive{
+		Color:  stringPtr("#d08770"),
+		Italic: boolPtr(true),
+	},
+	Strong: ansi.StylePrimitive{
+		Color: stringPtr("#ebcb8b"),
+		Bold:  boolPtr(true),
+	},
+	HorizontalRule: ansi.StylePrimitive{
+		Color:  stringPtr("#8B95A7"),
+		Format: "\n--------\n",
+	},
+	Item: ansi.StylePrimitive{
+		BlockPrefix: "• ",
+		Color:       stringPtr("#88c0d0"),
+	},
+	Enumeration: ansi.StylePrimitive{
+		BlockPrefix: ". ",
+		Color:       stringPtr("#8fbcbb"),
+	},
+	Task: ansi.StyleTask{
+		StylePrimitive: ansi.StylePrimitive{},
+		Ticked:         "[✓] ",
+		Unticked:       "[ ] ",
+	},
+	Link: ansi.StylePrimitive{
+		Color:     stringPtr("#81a1c1"),
+		Underline: boolPtr(true),
+	},
+	LinkText: ansi.StylePrimitive{
+		Color: stringPtr("#8fbcbb"),
+	},
+	Image: ansi.StylePrimitive{
+		Color:     stringPtr("#81a1c1"),
+		Underline: boolPtr(true),
+	},
+	ImageText: ansi.StylePrimitive{
+		Color:  stringPtr("#8fbcbb"),
+		Format: "Image: {{.text}} →",
+	},
+	Code: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Color: stringPtr("#a3be8c"),
+		},
+	},
+	CodeBlock: ansi.StyleCodeBlock{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color: stringPtr("#d8dee9"),
+			},
+			Margin: uintPtr(defaultMargin),
+		},
+		Chroma: &ansi.Chroma{
+			Text: ansi.StylePrimitive{
+				Color: stringPtr("#d8dee9"),
+			},
+			Error: ansi.StylePrimitive{
+				Color:           stringPtr("#d8dee9"),
+				BackgroundColor: stringPtr("#bf616a"),
+			},
+			Comment: ansi.StylePrimitive{
+				Color: stringPtr("#8B95A7"),
+			},
+			CommentPreproc: ansi.StylePrimitive{
+				Color: stringPtr("#b48ead"),
+			},
+			Keyword: ansi.StylePrimitive{
+				Color: stringPtr("#81a1c1"),
+			},
+			KeywordReserved: ansi.StylePrimitive{
+				Color: stringPtr("#81a1c1"),
+			},
+			KeywordNamespace: ansi.StylePrimitive{
+				Color: stringPtr("#81a1c1"),
+			},
+			KeywordType: ansi.StylePrimitive{
+				Color: stringPtr("#8fbcbb"),
+			},
+			Operator: ansi.StylePrimitive{
+				Color: stringPtr("#81a1c1"),
+			},
+			Punctuation: ansi.StylePrimitive{
+				Color: stringPtr("#d8dee9"),
+			},
+			Name: ansi.StylePrimitive{
+				Color: stringPtr("#8fbcbb"),
+			},
+			NameBuiltin: ansi.StylePrimitive{
+				Color: stringPtr("#8fbcbb"),
+			},
+			NameTag: ansi.StylePrimitive{
+				Color: stringPtr("#81a1c1"),
+			},
+			NameAttribute: ansi.StylePrimitive{
+				Color: stringPtr("#a3be8c"),
+			},
+			NameClass: ansi.StylePrimitive{
+				Color: stringPtr("#8fbcbb"),
+			},
+			NameConstant: ansi.StylePrimitive{
+				Color: stringPtr("#b48ead"),
+			},
+			NameDecorator: ansi.StylePrimitive{
+				Color: stringPtr("#d08770"),
+			},
+			NameFunction: ansi.StylePrimitive{
+				Color: stringPtr("#88c0d0"),
+			},
+			LiteralNumber: ansi.StylePrimitive{
+				Color: stringPtr("#b48ead"),
+			},
+			LiteralString: ansi.StylePrimitive{
+				Color: stringPtr("#a3be8c"),
+			},
+			LiteralStringEscape: ansi.StylePrimitive{
+				Color: stringPtr("#ebcb8b"),
+			},
+			GenericDeleted: ansi.StylePrimitive{
+				Color: stringPtr("#bf616a"),
+			},
+			GenericEmph: ansi.StylePrimitive{
+				Color:  stringPtr("#d08770"),
+				Italic: boolPtr(true),
+			},
+			GenericInserted: ansi.StylePrimitive{
+				Color: stringPtr("#a3be8c"),
+			},
+			GenericStrong: ansi.StylePrimitive{
+				Color: stringPtr("#ebcb8b"),
+				Bold:  boolPtr(true),
+			},
+			GenericSubheading: ansi.StylePrimitive{
+				Color: stringPtr("#88c0d0"),
+			},
+			Background: ansi.StylePrimitive{
+				BackgroundColor: stringPtr("#2e3440"),
+			},
+		},
+	},
+	Table: ansi.StyleTable{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{},
+		},
+	},
+	DefinitionDescription: ansi.StylePrimitive{
+		BlockPrefix: "\n🠶 ",
+	},
+}

--- a/styles/nord.json
+++ b/styles/nord.json
@@ -1,0 +1,189 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "color": "#d8dee9",
+    "margin": 2
+  },
+  "block_quote": {
+    "color": "#8B95A7",
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "color": "#d8dee9",
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "#88c0d0",
+    "bold": true
+  },
+  "h1": {
+    "prefix": "# "
+  },
+  "h2": {
+    "prefix": "## "
+  },
+  "h3": {
+    "prefix": "### "
+  },
+  "h4": {
+    "prefix": "#### "
+  },
+  "h5": {
+    "prefix": "##### "
+  },
+  "h6": {
+    "prefix": "###### "
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "color": "#d08770",
+    "italic": true
+  },
+  "strong": {
+    "color": "#ebcb8b",
+    "bold": true
+  },
+  "hr": {
+    "color": "#8B95A7",
+    "format": "\n--------\n"
+  },
+  "item": {
+    "block_prefix": "• ",
+    "color": "#88c0d0"
+  },
+  "enumeration": {
+    "block_prefix": ". ",
+    "color": "#8fbcbb"
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "#81a1c1",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#8fbcbb"
+  },
+  "image": {
+    "color": "#81a1c1",
+    "underline": true
+  },
+  "image_text": {
+    "color": "#8fbcbb",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "color": "#a3be8c"
+  },
+  "code_block": {
+    "color": "#d8dee9",
+    "margin": 2,
+    "chroma": {
+      "text": {
+        "color": "#d8dee9"
+      },
+      "error": {
+        "color": "#d8dee9",
+        "background_color": "#bf616a"
+      },
+      "comment": {
+        "color": "#8B95A7"
+      },
+      "comment_preproc": {
+        "color": "#b48ead"
+      },
+      "keyword": {
+        "color": "#81a1c1"
+      },
+      "keyword_reserved": {
+        "color": "#81a1c1"
+      },
+      "keyword_namespace": {
+        "color": "#81a1c1"
+      },
+      "keyword_type": {
+        "color": "#8fbcbb"
+      },
+      "operator": {
+        "color": "#81a1c1"
+      },
+      "punctuation": {
+        "color": "#d8dee9"
+      },
+      "name": {
+        "color": "#8fbcbb"
+      },
+      "name_builtin": {
+        "color": "#8fbcbb"
+      },
+      "name_tag": {
+        "color": "#81a1c1"
+      },
+      "name_attribute": {
+        "color": "#a3be8c"
+      },
+      "name_class": {
+        "color": "#8fbcbb"
+      },
+      "name_constant": {
+        "color": "#b48ead"
+      },
+      "name_decorator": {
+        "color": "#d08770"
+      },
+      "name_exception": {},
+      "name_function": {
+        "color": "#88c0d0"
+      },
+      "name_other": {},
+      "literal": {},
+      "literal_number": {
+        "color": "#b48ead"
+      },
+      "literal_date": {},
+      "literal_string": {
+        "color": "#a3be8c"
+      },
+      "literal_string_escape": {
+        "color": "#ebcb8b"
+      },
+      "generic_deleted": {
+        "color": "#bf616a"
+      },
+      "generic_emph": {
+        "color": "#d08770",
+        "italic": true
+      },
+      "generic_inserted": {
+        "color": "#a3be8c"
+      },
+      "generic_strong": {
+        "color": "#ebcb8b",
+        "bold": true
+      },
+      "generic_subheading": {
+        "color": "#88c0d0"
+      },
+      "background": {
+        "background_color": "#2e3440"
+      }
+    }
+  },
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/styles/styles.go
+++ b/styles/styles.go
@@ -19,6 +19,7 @@ const (
 	DarkStyle       = "dark"
 	DraculaStyle    = "dracula"
 	TokyoNightStyle = "tokyo-night"
+	NordStyle       = "nord"
 	LightStyle      = "light"
 	NoTTYStyle      = "notty"
 	PinkStyle       = "pink"
@@ -672,6 +673,7 @@ var (
 		// Popular themes
 		DraculaStyle:    &DraculaStyleConfig,
 		TokyoNightStyle: &TokyoNightStyleConfig,
+		NordStyle:       &NordStyleConfig,
 	}
 )
 


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
---

Hello, thanks for your awesome glow/glamour project.  I propose adding Nord theme for glamour. [Nord](https://www.nordtheme.com/) is an arctic, north-bluish color theme.

# Color Palette

The following palette is an optimized version from [opencode](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/cli/cmd/tui/context/theme/nord.json)  

| Element           | Color            |
| ----------------- | ---------------- |
| Body Text         | nord4 (#d8dee9)  |
| Heading           | nord8 (#88c0d0)  |
| Block Quote       | #8B95A7          |
| Horizontal Rule   | #8B95A7          |
| Italic / Emphasis | nord12 (#d08770) |
| Bold / Strong     | nord13 (#ebcb8b) |
| Link              | nord9 (#81a1c1)  |
| Link Text         | nord7 (#8fbcbb)  |
| Enumeration       | nord7 (#8fbcbb)  |
| List Item         | nord8 (#88c0d0)  |
| Inline Code       | nord14 (#a3be8c) |
| Code Block Text   | nord4 (#d8dee9)  |
| Chroma Comment    | #8B95A7          |
| Chroma Name (var) | nord7 (#8fbcbb)  |

# Screenshot

The font used in the following screenshot is `Iosevka Nerd Font Mono`.
<img width="3005" height="4927" alt="nord" src="https://github.com/user-attachments/assets/ece82666-f75f-40a7-bede-2ed6913911a8" />
