### PR TITLE
fix: close wrap writer before its downstream chain

### DIFF
--- a/ansi/blockelement.go
+++ b/ansi/blockelement.go
@@ -35,7 +35,7 @@ func (e *BlockElement) Finish(w io.Writer, ctx RenderContext) error {
 	if e.Margin { //nolint: nestif
 		s := lipgloss.Wrap(
 			bs.Current().Block.String(),
-			int(bs.Width(ctx)), //nolint: gosec
+			int(bs.Width(ctx)),
 			" ,.;-+|",
 		)
 

--- a/ansi/blockstack.go
+++ b/ansi/blockstack.go
@@ -59,10 +59,10 @@ func (s BlockStack) Margin() uint {
 
 // Width returns the available rendering width.
 func (s BlockStack) Width(ctx RenderContext) uint {
-	if s.Indent()+s.Margin()*2 > uint(ctx.options.WordWrap) { //nolint: gosec
+	if s.Indent()+s.Margin()*2 > uint(ctx.options.WordWrap) {
 		return 0
 	}
-	return uint(ctx.options.WordWrap) - s.Indent() - s.Margin()*2 //nolint: gosec
+	return uint(ctx.options.WordWrap) - s.Indent() - s.Margin()*2
 }
 
 // Parent returns the current BlockElement's parent.

--- a/ansi/codeblock.go
+++ b/ansi/codeblock.go
@@ -125,7 +125,7 @@ func (e *CodeBlockElement) Render(w io.Writer, ctx RenderContext) error {
 		mutex.Unlock()
 	}
 
-	iw := NewIndentWriter(w, int(indentation+margin), func(_ io.Writer) { //nolint:gosec
+	iw := NewIndentWriter(w, int(indentation+margin), func(_ io.Writer) {
 		_, _ = renderText(w, bs.Current().Style.StylePrimitive, " ")
 	})
 	defer iw.Close() //nolint:errcheck

--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -136,7 +136,7 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		if node.Parent().(*ast.List).IsOrdered() {
 			e = l
 			if node.Parent().(*ast.List).Start != 1 {
-				e += uint(node.Parent().(*ast.List).Start) - 1 //nolint: gosec
+				e += uint(node.Parent().(*ast.List).Start) - 1
 			}
 		}
 

--- a/ansi/heading.go
+++ b/ansi/heading.go
@@ -65,7 +65,7 @@ func (e *HeadingElement) Finish(w io.Writer, ctx RenderContext) error {
 	mw := NewMarginWriter(ctx, w, rules)
 	defer mw.Close() //nolint:errcheck
 
-	flow := lipgloss.Wrap(bs.Current().Block.String(), int(bs.Width(ctx)), "") //nolint: gosec
+	flow := lipgloss.Wrap(bs.Current().Block.String(), int(bs.Width(ctx)), "")
 	_, err := io.WriteString(mw, flow)
 	if err != nil {
 		return fmt.Errorf("glamour: error writing to writer: %w", err)

--- a/ansi/listitem.go
+++ b/ansi/listitem.go
@@ -17,7 +17,7 @@ func (e *ItemElement) Render(w io.Writer, ctx RenderContext) error {
 	if e.IsOrdered {
 		el = &BaseElement{
 			Style:  ctx.options.Styles.Enumeration,
-			Prefix: strconv.FormatInt(int64(e.Enumeration), 10), //nolint: gosec
+			Prefix: strconv.FormatInt(int64(e.Enumeration), 10), //nolint:gosec
 		}
 	} else {
 		el = &BaseElement{

--- a/ansi/margin.go
+++ b/ansi/margin.go
@@ -32,7 +32,7 @@ func NewMarginWriter(ctx RenderContext, w io.Writer, rules StyleBlock) *MarginWr
 		margin = *rules.Margin
 	}
 
-	pw := NewPaddingWriter(w, int(bs.Width(ctx)), func(_ io.Writer) { //nolint:gosec
+	pw := NewPaddingWriter(w, int(bs.Width(ctx)), func(_ io.Writer) {
 		_, _ = renderText(w, rules.StylePrimitive, " ")
 	})
 
@@ -40,7 +40,7 @@ func NewMarginWriter(ctx RenderContext, w io.Writer, rules StyleBlock) *MarginWr
 	if rules.IndentToken != nil {
 		ic = *rules.IndentToken
 	}
-	iw := NewIndentWriter(pw, int(indentation+margin), func(_ io.Writer) { //nolint:gosec
+	iw := NewIndentWriter(pw, int(indentation+margin), func(_ io.Writer) {
 		_, _ = renderText(w, bs.Parent().Style.StylePrimitive, ic)
 	})
 

--- a/ansi/margin.go
+++ b/ansi/margin.go
@@ -62,8 +62,8 @@ func (w *MarginWriter) Write(b []byte) (int, error) {
 // Close closes the [MarginWriter].
 func (w *MarginWriter) Close() error {
 	var werr error
-	if w, ok := w.w.(io.WriteCloser); ok {
-		werr = w.Close()
+	if c, ok := w.w.(io.WriteCloser); ok {
+		werr = c.Close()
 	}
 
 	return errors.Join(werr, w.iw.Close())
@@ -217,10 +217,15 @@ func (w *IndentWriter) Write(p []byte) (int, error) {
 
 // Close closes the [IndentWriter].
 func (w *IndentWriter) Close() error {
-	var werr error
-	if w, ok := w.w.(io.WriteCloser); ok {
-		werr = w.Close()
+	// Close the wrap writer (w.pw) before the downstream writer (w.w). w.pw
+	// wraps w.w, so its Close flushes a trailing style/link reset back through
+	// w.w. Closing w.w first would return its parser to the pool and nil it
+	// out, turning that flush into a write on a closed writer.
+	werr := w.pw.Close()
+
+	if c, ok := w.w.(io.WriteCloser); ok {
+		werr = errors.Join(werr, c.Close())
 	}
 
-	return errors.Join(werr, w.pw.Close())
+	return werr
 }

--- a/ansi/margin_test.go
+++ b/ansi/margin_test.go
@@ -1,0 +1,46 @@
+package ansi
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+// TestIndentWriterCloseOrder guards against a use-after-close crash in the
+// writer chain. IndentWriter.pw wraps IndentWriter.w, so closing w before pw
+// used to tear down the writer that pw's closing style/link reset flushes
+// through, panicking on a nil ANSI parser. Closing pw first avoids that.
+func TestIndentWriterCloseOrder(t *testing.T) {
+	var buf bytes.Buffer
+
+	// pw stands in for the downstream PaddingWriter: a passthrough whose own
+	// underlying WrapWriter gets closed when pw is closed.
+	pw := newWrapCloser(&buf)
+	iw := NewIndentWriter(pw, 2, nil)
+
+	// Write content carrying an open SGR style so closing flushes a reset.
+	if _, err := io.WriteString(iw, "\x1b[1mhello\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Must not panic.
+	if err := iw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+// wrapCloser models glamour's PaddingWriter: it forwards writes through an
+// inner lipgloss WrapWriter and closes that writer on Close.
+type wrapCloser struct {
+	w *lipgloss.WrapWriter
+}
+
+func newWrapCloser(w *bytes.Buffer) *wrapCloser {
+	return &wrapCloser{w: lipgloss.NewWrapWriter(w)}
+}
+
+func (c *wrapCloser) Write(p []byte) (int, error) { return c.w.Write(p) }
+
+func (c *wrapCloser) Close() error { return c.w.Close() }

--- a/ansi/paragraph.go
+++ b/ansi/paragraph.go
@@ -45,7 +45,7 @@ func (e *ParagraphElement) Finish(w io.Writer, ctx RenderContext) error {
 		if !ctx.options.PreserveNewLines {
 			blk = strings.ReplaceAll(blk, "\n", " ")
 		}
-		flow := lipgloss.Wrap(blk, int(bs.Width(ctx)), "") //nolint: gosec
+		flow := lipgloss.Wrap(blk, int(bs.Width(ctx)), "")
 
 		_, err := io.WriteString(mw, flow)
 		if err != nil {

--- a/ansi/table.go
+++ b/ansi/table.go
@@ -48,7 +48,7 @@ func (e *TableElement) Render(w io.Writer, ctx RenderContext) error {
 		margin = *rules.Margin
 	}
 
-	iw := NewIndentWriter(w, int(indentation+margin), func(_ io.Writer) { //nolint:gosec
+	iw := NewIndentWriter(w, int(indentation+margin), func(_ io.Writer) {
 		_, _ = renderText(w, bs.Current().Style.StylePrimitive, " ")
 	})
 	defer iw.Close() //nolint:errcheck
@@ -57,7 +57,7 @@ func (e *TableElement) Render(w io.Writer, ctx RenderContext) error {
 
 	_, _ = renderText(iw, bs.Current().Style.StylePrimitive, rules.BlockPrefix)
 	_, _ = renderText(iw, style, rules.Prefix)
-	width := int(ctx.blockStack.Width(ctx)) //nolint: gosec
+	width := int(ctx.blockStack.Width(ctx))
 
 	wrap := true
 	if ctx.options.TableWrap != nil {
@@ -86,7 +86,7 @@ func (e *TableElement) setStyles(ctx RenderContext) {
 
 		// Override with custom styles
 		if m := ctx.options.Styles.Table.Margin; m != nil {
-			st = st.Padding(0, int(*m)) //nolint: gosec
+			st = st.Padding(0, int(*m))
 		}
 		switch e.table.Alignments[col] {
 		case astext.AlignLeft:

--- a/ansi/table_links.go
+++ b/ansi/table_links.go
@@ -38,7 +38,7 @@ func (e *TableElement) printTableLinks(ctx RenderContext) {
 	}
 
 	w := ctx.blockStack.Current().Block
-	termWidth := int(ctx.blockStack.Width(ctx)) //nolint: gosec
+	termWidth := int(ctx.blockStack.Width(ctx))
 
 	renderLinkText := func(link tableLink, position, padding int) string {
 		token := strings.Repeat(" ", padding)

--- a/styles/dracula.go
+++ b/styles/dracula.go
@@ -41,27 +41,27 @@ var DraculaStyleConfig = ansi.StyleConfig{
 	},
 	H2: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "## ",
+			Prefix: defaultHeadingPrefixH2,
 		},
 	},
 	H3: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "### ",
+			Prefix: defaultHeadingPrefixH3,
 		},
 	},
 	H4: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "#### ",
+			Prefix: defaultHeadingPrefixH4,
 		},
 	},
 	H5: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "##### ",
+			Prefix: defaultHeadingPrefixH5,
 		},
 	},
 	H6: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "###### ",
+			Prefix: defaultHeadingPrefixH6,
 		},
 	},
 	Strikethrough: ansi.StylePrimitive{
@@ -77,7 +77,7 @@ var DraculaStyleConfig = ansi.StyleConfig{
 	},
 	HorizontalRule: ansi.StylePrimitive{
 		Color:  stringPtr("#6272A4"),
-		Format: "\n--------\n",
+		Format: defaultHorizontalRule,
 	},
 	Item: ansi.StylePrimitive{
 		BlockPrefix: "• ",
@@ -88,8 +88,8 @@ var DraculaStyleConfig = ansi.StyleConfig{
 	},
 	Task: ansi.StyleTask{
 		StylePrimitive: ansi.StylePrimitive{},
-		Ticked:         "[✓] ",
-		Unticked:       "[ ] ",
+		Ticked:         defaultTaskTickedPrefix,
+		Unticked:       defaultTaskUntickedPrefix,
 	},
 	Link: ansi.StylePrimitive{
 		Color:     stringPtr("#8be9fd"),
@@ -104,7 +104,7 @@ var DraculaStyleConfig = ansi.StyleConfig{
 	},
 	ImageText: ansi.StylePrimitive{
 		Color:  stringPtr("#ff79c6"),
-		Format: "Image: {{.text}} →",
+		Format: defaultImageFormat,
 	},
 	Code: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
@@ -211,6 +211,6 @@ var DraculaStyleConfig = ansi.StyleConfig{
 		},
 	},
 	DefinitionDescription: ansi.StylePrimitive{
-		BlockPrefix: "\n🠶 ",
+		BlockPrefix: defaultArrowBlockPrefix,
 	},
 }

--- a/styles/styles.go
+++ b/styles/styles.go
@@ -11,6 +11,17 @@ const (
 	defaultListIndent      = 2
 	defaultListLevelIndent = 4
 	defaultMargin          = 2
+
+	defaultHeadingPrefixH2    = "## "
+	defaultHeadingPrefixH3    = "### "
+	defaultHeadingPrefixH4    = "#### "
+	defaultHeadingPrefixH5    = "##### "
+	defaultHeadingPrefixH6    = "###### "
+	defaultTaskTickedPrefix   = "[✓] "
+	defaultTaskUntickedPrefix = "[ ] "
+	defaultImageFormat        = "Image: {{.text}} →"
+	defaultHorizontalRule     = "\n--------\n"
+	defaultArrowBlockPrefix   = "\n🠶 "
 )
 
 // Default styles.
@@ -60,27 +71,27 @@ var (
 		},
 		H2: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "## ",
+				Prefix: defaultHeadingPrefixH2,
 			},
 		},
 		H3: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "### ",
+				Prefix: defaultHeadingPrefixH3,
 			},
 		},
 		H4: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "#### ",
+				Prefix: defaultHeadingPrefixH4,
 			},
 		},
 		H5: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "##### ",
+				Prefix: defaultHeadingPrefixH5,
 			},
 		},
 		H6: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "###### ",
+				Prefix: defaultHeadingPrefixH6,
 			},
 		},
 		Strikethrough: ansi.StylePrimitive{
@@ -96,7 +107,7 @@ var (
 			BlockSuffix: "**",
 		},
 		HorizontalRule: ansi.StylePrimitive{
-			Format: "\n--------\n",
+			Format: defaultHorizontalRule,
 		},
 		Item: ansi.StylePrimitive{
 			BlockPrefix: "• ",
@@ -106,10 +117,10 @@ var (
 		},
 		Task: ansi.StyleTask{
 			Ticked:   "[x] ",
-			Unticked: "[ ] ",
+			Unticked: defaultTaskUntickedPrefix,
 		},
 		ImageText: ansi.StylePrimitive{
-			Format: "Image: {{.text}} →",
+			Format: defaultImageFormat,
 		},
 		Code: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
@@ -168,27 +179,27 @@ var (
 		},
 		H2: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "## ",
+				Prefix: defaultHeadingPrefixH2,
 			},
 		},
 		H3: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "### ",
+				Prefix: defaultHeadingPrefixH3,
 			},
 		},
 		H4: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "#### ",
+				Prefix: defaultHeadingPrefixH4,
 			},
 		},
 		H5: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "##### ",
+				Prefix: defaultHeadingPrefixH5,
 			},
 		},
 		H6: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "###### ",
+				Prefix: defaultHeadingPrefixH6,
 				Color:  stringPtr("35"),
 				Bold:   boolPtr(false),
 			},
@@ -204,7 +215,7 @@ var (
 		},
 		HorizontalRule: ansi.StylePrimitive{
 			Color:  stringPtr("240"),
-			Format: "\n--------\n",
+			Format: defaultHorizontalRule,
 		},
 		Item: ansi.StylePrimitive{
 			BlockPrefix: "• ",
@@ -214,8 +225,8 @@ var (
 		},
 		Task: ansi.StyleTask{
 			StylePrimitive: ansi.StylePrimitive{},
-			Ticked:         "[✓] ",
-			Unticked:       "[ ] ",
+			Ticked:         defaultTaskTickedPrefix,
+			Unticked:       defaultTaskUntickedPrefix,
 		},
 		Link: ansi.StylePrimitive{
 			Color:     stringPtr("30"),
@@ -231,7 +242,7 @@ var (
 		},
 		ImageText: ansi.StylePrimitive{
 			Color:  stringPtr("243"),
-			Format: "Image: {{.text}} →",
+			Format: defaultImageFormat,
 		},
 		Code: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
@@ -338,7 +349,7 @@ var (
 			},
 		},
 		DefinitionDescription: ansi.StylePrimitive{
-			BlockPrefix: "\n🠶 ",
+			BlockPrefix: defaultArrowBlockPrefix,
 		},
 	}
 
@@ -378,27 +389,27 @@ var (
 		},
 		H2: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "## ",
+				Prefix: defaultHeadingPrefixH2,
 			},
 		},
 		H3: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "### ",
+				Prefix: defaultHeadingPrefixH3,
 			},
 		},
 		H4: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "#### ",
+				Prefix: defaultHeadingPrefixH4,
 			},
 		},
 		H5: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "##### ",
+				Prefix: defaultHeadingPrefixH5,
 			},
 		},
 		H6: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix: "###### ",
+				Prefix: defaultHeadingPrefixH6,
 				Bold:   boolPtr(false),
 			},
 		},
@@ -413,7 +424,7 @@ var (
 		},
 		HorizontalRule: ansi.StylePrimitive{
 			Color:  stringPtr("249"),
-			Format: "\n--------\n",
+			Format: defaultHorizontalRule,
 		},
 		Item: ansi.StylePrimitive{
 			BlockPrefix: "• ",
@@ -423,8 +434,8 @@ var (
 		},
 		Task: ansi.StyleTask{
 			StylePrimitive: ansi.StylePrimitive{},
-			Ticked:         "[✓] ",
-			Unticked:       "[ ] ",
+			Ticked:         defaultTaskTickedPrefix,
+			Unticked:       defaultTaskUntickedPrefix,
 		},
 		Link: ansi.StylePrimitive{
 			Color:     stringPtr("36"),
@@ -440,7 +451,7 @@ var (
 		},
 		ImageText: ansi.StylePrimitive{
 			Color:  stringPtr("243"),
-			Format: "Image: {{.text}} →",
+			Format: defaultImageFormat,
 		},
 		Code: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
@@ -547,7 +558,7 @@ var (
 			},
 		},
 		DefinitionDescription: ansi.StylePrimitive{
-			BlockPrefix: "\n🠶 ",
+			BlockPrefix: defaultArrowBlockPrefix,
 		},
 	}
 
@@ -624,8 +635,8 @@ var (
 			BlockPrefix: ". ",
 		},
 		Task: ansi.StyleTask{
-			Ticked:   "[✓] ",
-			Unticked: "[ ] ",
+			Ticked:   defaultTaskTickedPrefix,
+			Unticked: defaultTaskUntickedPrefix,
 		},
 		Link: ansi.StylePrimitive{
 			Color:     stringPtr("99"),
@@ -652,7 +663,7 @@ var (
 		DefinitionList: ansi.StyleBlock{},
 		DefinitionTerm: ansi.StylePrimitive{},
 		DefinitionDescription: ansi.StylePrimitive{
-			BlockPrefix: "\n🠶 ",
+			BlockPrefix: defaultArrowBlockPrefix,
 		},
 		HTMLBlock: ansi.StyleBlock{},
 		HTMLSpan:  ansi.StyleBlock{},

--- a/styles/tokyo-night.go
+++ b/styles/tokyo-night.go
@@ -40,27 +40,27 @@ var TokyoNightStyleConfig = ansi.StyleConfig{
 	},
 	H2: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "## ",
+			Prefix: defaultHeadingPrefixH2,
 		},
 	},
 	H3: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "### ",
+			Prefix: defaultHeadingPrefixH3,
 		},
 	},
 	H4: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "#### ",
+			Prefix: defaultHeadingPrefixH4,
 		},
 	},
 	H5: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "##### ",
+			Prefix: defaultHeadingPrefixH5,
 		},
 	},
 	H6: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
-			Prefix: "###### ",
+			Prefix: defaultHeadingPrefixH6,
 		},
 	},
 	Strikethrough: ansi.StylePrimitive{
@@ -74,7 +74,7 @@ var TokyoNightStyleConfig = ansi.StyleConfig{
 	},
 	HorizontalRule: ansi.StylePrimitive{
 		Color:  stringPtr("#565f89"),
-		Format: "\n--------\n",
+		Format: defaultHorizontalRule,
 	},
 	Item: ansi.StylePrimitive{
 		BlockPrefix: "• ",
@@ -85,8 +85,8 @@ var TokyoNightStyleConfig = ansi.StyleConfig{
 	},
 	Task: ansi.StyleTask{
 		StylePrimitive: ansi.StylePrimitive{},
-		Ticked:         "[✓] ",
-		Unticked:       "[ ] ",
+		Ticked:         defaultTaskTickedPrefix,
+		Unticked:       defaultTaskUntickedPrefix,
 	},
 	Link: ansi.StylePrimitive{
 		Color:     stringPtr("#7aa2f7"),
@@ -101,7 +101,7 @@ var TokyoNightStyleConfig = ansi.StyleConfig{
 	},
 	ImageText: ansi.StylePrimitive{
 		Color:  stringPtr("#2ac3de"),
-		Format: "Image: {{.text}} →",
+		Format: defaultImageFormat,
 	},
 	Code: ansi.StyleBlock{
 		StylePrimitive: ansi.StylePrimitive{
@@ -204,6 +204,6 @@ var TokyoNightStyleConfig = ansi.StyleConfig{
 		},
 	},
 	DefinitionDescription: ansi.StylePrimitive{
-		BlockPrefix: "\n🠶 ",
+		BlockPrefix: defaultArrowBlockPrefix,
 	},
 }


### PR DESCRIPTION
## Summary

Rendering markdown that leaves a text style open across an indent or margin boundary could crash the program. When a block finishes, a trailing style reset is flushed to balance the open style. `IndentWriter.Close` tore down its downstream writer *before* flushing its own wrapping writer, so that reset was routed through an already-closed writer and dereferenced a nil ANSI parser.

This shows up most often when rendering partial or streamed markdown, where a styled run can be split across a render boundary so the closing reset has not yet arrived.

The underlying nil dereference is also being hardened in lipgloss (charmbracelet/lipgloss#699), but the close ordering here is wrong on its own and is the direct cause, so it is worth fixing independently.

## Fix

In `IndentWriter.Close`, flush the wrapping writer first so the trailing reset reaches a live writer, then close the downstream chain.

## Test

`TestIndentWriterCloseOrder` builds the indent → wrap writer chain, writes content carrying an open style, and closes it. It panics at the exact crash site without the fix and passes with it (verified against the released lipgloss, so the ordering fix stands on its own).


💘 Generated with Crush