### PR TITLE
fix(ansi): skip nil children in emphasis and link renderers

### DIFF
--- a/ansi/emphasis.go
+++ b/ansi/emphasis.go
@@ -32,6 +32,9 @@ func (e *EmphasisElement) StyleOverrideRender(w io.Writer, ctx RenderContext, st
 
 func (e *EmphasisElement) doRender(w io.Writer, ctx RenderContext, style StylePrimitive) error {
 	for _, child := range e.Children {
+		if child == nil {
+			continue
+		}
 		if r, ok := child.(StyleOverriderElementRenderer); ok {
 			if err := r.StyleOverrideRender(w, ctx, style); err != nil {
 				return fmt.Errorf("glamour: error rendering with style: %w", err)

--- a/ansi/link.go
+++ b/ansi/link.go
@@ -42,6 +42,9 @@ func (e *LinkElement) Render(w io.Writer, ctx RenderContext) error {
 
 func (e *LinkElement) renderTextPart(w io.Writer, ctx RenderContext) error {
 	for _, child := range e.Children {
+		if child == nil {
+			continue
+		}
 		if r, ok := child.(StyleOverriderElementRenderer); ok { //nolint:nestif
 			var b bytes.Buffer
 			st := ctx.options.Styles.LinkText

--- a/ansi/nilchild_test.go
+++ b/ansi/nilchild_test.go
@@ -1,0 +1,20 @@
+package ansi
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestEmphasisRenderSkipsNilChild guards against a nil pointer dereference when
+// an emphasis element holds a child whose node kind has no renderer. Such
+// children enter the Children slice as a nil ElementRenderer (NewElement
+// returns an empty Element for unhandled kinds), and doRender used to call
+// child.Render on them directly, panicking. The renderer must tolerate a nil
+// child instead of crashing.
+func TestEmphasisRenderSkipsNilChild(t *testing.T) {
+	var buf bytes.Buffer
+	e := &EmphasisElement{Children: []ElementRenderer{nil}}
+	if err := e.Render(&buf, RenderContext{}); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Rendering markdown where an inline element (emphasis, strong, or a link) contains a child node that has no renderer crashes with a nil pointer dereference. `NewElement` returns an empty `Element` for unhandled node kinds, so its `Renderer` is nil, and the inline child-collection loops append that nil straight into the `Children` slice. `EmphasisElement.doRender` and `LinkElement.renderTextPart` then call `child.Render` on it and panic. The top-level renderer already guards this with `if e.Renderer != nil`, but the inline renderers do not. Fixes #576.

## Fix

Skip nil children in `EmphasisElement.doRender` and `LinkElement.renderTextPart` before dispatching to them, matching the guard the top-level renderer already uses.

## Test

`TestEmphasisRenderSkipsNilChild` renders an emphasis element holding a nil child. It panics at the crash site without the fix and passes with it.
