### PR TITLE
fix(ansi): collapse soft line breaks in list items by default

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -172,8 +172,13 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		n := node.(*ast.Text)
 		s := string(n.Segment.Value(source))
 
-		if n.HardLineBreak() || (n.SoftLineBreak()) {
+		switch {
+		case n.HardLineBreak():
 			s += "\n"
+		case n.SoftLineBreak() && ctx.options.PreserveNewLines:
+			s += "\n"
+		case n.SoftLineBreak():
+			s += " "
 		}
 		return Element{
 			Renderer: &BaseElement{

--- a/glamour_test.go
+++ b/glamour_test.go
@@ -323,3 +323,56 @@ func TestWithChromaFormatterCustom(t *testing.T) {
 
 	golden.RequireEqual(t, []byte(b))
 }
+
+func TestListSoftLineBreaks(t *testing.T) {
+	md := "- This shouldn't have\n  a line break\n- This should have\\\n  a line break\n"
+
+	t.Run("default", func(t *testing.T) {
+		r, err := NewTermRenderer(
+			WithStandardStyle(styles.DarkStyle),
+			WithWordWrap(80),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		out, err := r.Render(md)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		plain := ansiRegex.ReplaceAllString(out, "")
+		if strings.Contains(plain, "have\n  a line break") || strings.Contains(plain, "have\n a line break") {
+			t.Fatalf("expected soft line break in list item to collapse, got:\n%s", plain)
+		}
+		if !strings.Contains(plain, "have a line break") {
+			t.Fatalf("expected collapsed list item text, got:\n%s", plain)
+		}
+		if strings.Contains(plain, "should have a line break") {
+			t.Fatalf("expected hard line break to remain on separate lines, got:\n%s", plain)
+		}
+	})
+
+	t.Run("preserve newlines", func(t *testing.T) {
+		r, err := NewTermRenderer(
+			WithStandardStyle(styles.DarkStyle),
+			WithWordWrap(80),
+			WithPreservedNewLines(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		out, err := r.Render("- soft\n  break\n")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		plain := ansiRegex.ReplaceAllString(out, "")
+		if strings.Contains(plain, "soft break") {
+			t.Fatalf("expected soft line break to be preserved, got:\n%s", plain)
+		}
+	})
+}
+
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)


### PR DESCRIPTION
## Summary
Soft line breaks in list item text were always rendered as hard newlines, even when `PreserveNewLines` is disabled.

## Motivation
List items render through `TextBlock` nodes, not `Paragraph`, so paragraph-level newline collapsing never applied. This caused glow #858: soft breaks inside list items were preserved while body text correctly collapsed them.

## Changes
- In `ansi/elements.go`, render soft breaks as a space by default and as `\n` only when `PreserveNewLines` is enabled
- Hard line breaks (`\` or two trailing spaces) still render as newlines
- Added `TestListSoftLineBreaks` covering soft vs hard breaks in bullet lists

## Tests
- `go test ./... -count=1` — all pass

## Notes
Glow currently depends on glamour v0.10.0; this fix lands in glamour v2 main. A follow-up glow PR can bump the dependency once released.

Related to charmbracelet/glow#858