### PR TITLE
fix(ansi): skip nil inline child renderers

### DIFF
--- a/ansi/emphasis.go
+++ b/ansi/emphasis.go
@@ -32,6 +32,9 @@ func (e *EmphasisElement) StyleOverrideRender(w io.Writer, ctx RenderContext, st
 
 func (e *EmphasisElement) doRender(w io.Writer, ctx RenderContext, style StylePrimitive) error {
 	for _, child := range e.Children {
+		if child == nil {
+			continue
+		}
 		if r, ok := child.(StyleOverriderElementRenderer); ok {
 			if err := r.StyleOverrideRender(w, ctx, style); err != nil {
 				return fmt.Errorf("glamour: error rendering with style: %w", err)

--- a/ansi/link.go
+++ b/ansi/link.go
@@ -42,6 +42,9 @@ func (e *LinkElement) Render(w io.Writer, ctx RenderContext) error {
 
 func (e *LinkElement) renderTextPart(w io.Writer, ctx RenderContext) error {
 	for _, child := range e.Children {
+		if child == nil {
+			continue
+		}
 		if r, ok := child.(StyleOverriderElementRenderer); ok { //nolint:nestif
 			var b bytes.Buffer
 			st := ctx.options.Styles.LinkText

--- a/ansi/nil_children_test.go
+++ b/ansi/nil_children_test.go
@@ -1,0 +1,78 @@
+package ansi
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestEmphasisElementSkipsNilChildren(t *testing.T) {
+	t.Parallel()
+
+	el := &EmphasisElement{
+		Children: []ElementRenderer{
+			nil,
+			&BaseElement{Token: "ok"},
+		},
+		Level: 1,
+	}
+
+	var buf bytes.Buffer
+	ctx := NewRenderContext(Options{})
+
+	if err := el.Render(&buf, ctx); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if got := buf.String(); !strings.Contains(got, "ok") {
+		t.Fatalf("expected rendered output to contain %q, got %q", "ok", got)
+	}
+}
+
+func TestLinkElementSkipsNilChildren(t *testing.T) {
+	t.Parallel()
+
+	el := &LinkElement{
+		URL: "https://example.com",
+		Children: []ElementRenderer{
+			nil,
+			&BaseElement{Token: "link"},
+		},
+	}
+
+	var buf bytes.Buffer
+	ctx := NewRenderContext(Options{})
+
+	if err := el.Render(&buf, ctx); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if got := buf.String(); !strings.Contains(got, "link") {
+		t.Fatalf("expected rendered output to contain %q, got %q", "link", got)
+	}
+}
+
+func TestTableCellElementSkipsNilChildren(t *testing.T) {
+	t.Parallel()
+
+	el := &TableCellElement{
+		Children: []ElementRenderer{
+			nil,
+			&BaseElement{Token: "cell"},
+		},
+	}
+
+	ctx := NewRenderContext(Options{})
+
+	if err := el.Render(nil, ctx); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if len(ctx.table.row) != 1 {
+		t.Fatalf("expected 1 table row cell, got %d", len(ctx.table.row))
+	}
+
+	if !strings.Contains(ctx.table.row[0], "cell") {
+		t.Fatalf("expected table cell to contain %q, got %q", "cell", ctx.table.row[0])
+	}
+}

--- a/ansi/table.go
+++ b/ansi/table.go
@@ -177,6 +177,9 @@ func (e *TableCellElement) Render(_ io.Writer, ctx RenderContext) error {
 	var b bytes.Buffer
 	style := ctx.options.Styles.Table.StylePrimitive
 	for _, child := range e.Children {
+		if child == nil {
+			continue
+		}
 		if r, ok := child.(StyleOverriderElementRenderer); ok {
 			if err := r.StyleOverrideRender(&b, ctx, style); err != nil {
 				return fmt.Errorf("glamour: error rendering with style: %w", err)


### PR DESCRIPTION
## Summary

Guard emphasis, link, and table cell renderers against nil children when Goldmark inline nodes are unhandled by `NewElement`. This prevents panics when custom or extension inline nodes appear inside inline structures.

Fixes #576

## Motivation

When Glamour encounters unhandled or custom inline nodes (e.g. from Goldmark parser extensions), `NewElement` falls through to the default case and returns an `Element` with a nil `Renderer`. That nil value is appended to `Children` slices for emphasis, links, and table cells. Calling `child.Render()` on these nil interface values causes a nil pointer dereference panic.

## Changes

- Add nil checks in `EmphasisElement.doRender`, `LinkElement.renderTextPart`, and `TableCellElement.Render` before invoking child renderers
- Add unit tests covering all three element types with a nil child followed by a valid child

## Tests

- `go test ./ansi/ -run 'Test.*SkipsNilChildren' -v -count=1` — PASS
- `go test ./... -count=1` — PASS

## Notes

- Unhandled nodes still log the existing `Warning: unhandled element` message and produce no output; this change only prevents the panic.
- Pre-PR review: composer-2.5 reviewed — APPROVE.