### PR TITLE
docs: point GoDoc badge to charm.land/glamour/v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p>
     <img src="https://github.com/user-attachments/assets/23aabf2a-8bd8-4e7b-bb50-993bce32541d" width="300" alt="Glamour Title Treatment"><br>
     <a href="https://github.com/charmbracelet/glamour/releases"><img src="https://img.shields.io/github/release/charmbracelet/glamour.svg" alt="Latest Release"></a>
-    <a href="https://pkg.go.dev/github.com/charmbracelet/glamour?tab=doc"><img src="https://godoc.org/github.com/golang/gddo?status.svg" alt="GoDoc"></a>
+    <a href="https://pkg.go.dev/charm.land/glamour/v2"><img src="https://godoc.org/github.com/golang/gddo?status.svg" alt="GoDoc"></a>
     <a href="https://github.com/charmbracelet/glamour/actions"><img src="https://github.com/charmbracelet/glamour/workflows/build/badge.svg" alt="Build Status"></a>
     <a href="https://coveralls.io/github/charmbracelet/glamour?branch=master"><img src="https://coveralls.io/repos/github/charmbracelet/glamour/badge.svg?branch=master" alt="Coverage Status"></a>
     <a href="https://goreportcard.com/report/charmbracelet/glamour"><img src="https://goreportcard.com/badge/charmbracelet/glamour" alt="Go ReportCard"></a>


### PR DESCRIPTION
## Summary

Update the README GoDoc badge link to point at the v2 module path (`charm.land/glamour/v2`) instead of the legacy v1 path (`github.com/charmbracelet/glamour`).

Fixes #581

## Motivation

Glamour v2 uses the `charm.land/glamour/v2` module path (as shown in the README usage examples and `go.mod`), but the GoDoc badge still linked to the v1 package on pkg.go.dev. Clicking the badge took readers to outdated v1 documentation.

## Changes

- Update the GoDoc badge `href` in `README.md` from `https://pkg.go.dev/github.com/charmbracelet/glamour?tab=doc` to `https://pkg.go.dev/charm.land/glamour/v2`

## Tests

- `go test ./...` — all packages pass

## Notes

Documentation-only change; no code behavior affected.