### PR TITLE
Add Rosé Pine and Rosé Pine Dawn styles

### DIFF
--- a/gallery.sh
+++ b/gallery.sh
@@ -6,7 +6,7 @@ if ! command -v freeze &> /dev/null; then
     exit 1
 fi
 
-defaultStyles=("ascii" "auto" "dark" "dracula" "light" "notty" "pink")
+defaultStyles=("ascii" "auto" "dark" "dracula" "light" "notty" "pink" "rose-pine" "rose-pine-dawn")
 
 for style in "${defaultStyles[@]}"; do
     echo "Generating screenshot for ${style}"

--- a/styles/gallery/README.md
+++ b/styles/gallery/README.md
@@ -21,3 +21,11 @@ Pronounced _naughty_.
 ## Tokyo Night
 
 ![Tokyo Night Style](./tokyo-night.png)
+
+## Rosé Pine
+
+![Rosé Pine Style](./rose-pine.png)
+
+## Rosé Pine Dawn
+
+![Rosé Pine Dawn Style](./rose-pine-dawn.png)

--- a/styles/gallery/rose-pine-dawn.png
+++ b/styles/gallery/rose-pine-dawn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbad1e282274486ec97ab6688afbab95a7758878b50b362a6a4686e1a29790fe
+size 20592

--- a/styles/gallery/rose-pine.png
+++ b/styles/gallery/rose-pine.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ea5296f4bdd168728c5e1194075d54dbac39616d0e38958e16ddab9b69bbbcb
+size 19663

--- a/styles/rose-pine-builder.go
+++ b/styles/rose-pine-builder.go
@@ -1,0 +1,242 @@
+package styles
+
+import "charm.land/glamour/v2/ansi"
+
+type rosePinePalette struct {
+	Base    string
+	Surface string
+	Overlay string
+	Muted   string
+	Subtle  string
+	Text    string
+	Love    string
+	Gold    string
+	Rose    string
+	Pine    string
+	Foam    string
+	Iris    string
+}
+
+func buildRosePineStyleConfig(p rosePinePalette) ansi.StyleConfig {
+	return ansi.StyleConfig{
+		Document: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				BlockPrefix: "\n",
+				BlockSuffix: "\n",
+				Color:       stringPtr(p.Text),
+			},
+			Margin: uintPtr(defaultMargin),
+		},
+		BlockQuote: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:  stringPtr(p.Muted),
+				Italic: boolPtr(true),
+			},
+			Indent:      uintPtr(1),
+			IndentToken: stringPtr("│ "),
+		},
+		Paragraph: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{},
+		},
+		List: ansi.StyleList{
+			LevelIndent: defaultListIndent,
+			StyleBlock: ansi.StyleBlock{
+				StylePrimitive: ansi.StylePrimitive{
+					Color: stringPtr(p.Text),
+				},
+			},
+		},
+		Heading: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				BlockSuffix: "\n",
+				Color:       stringPtr(p.Love),
+				Bold:        boolPtr(true),
+			},
+		},
+		H1: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: "# ",
+			},
+		},
+		H2: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: defaultHeadingPrefixH2,
+			},
+		},
+		H3: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: defaultHeadingPrefixH3,
+			},
+		},
+		H4: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: defaultHeadingPrefixH4,
+			},
+		},
+		H5: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: defaultHeadingPrefixH5,
+			},
+		},
+		H6: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Prefix: defaultHeadingPrefixH6,
+			},
+		},
+		Text: ansi.StylePrimitive{},
+		Strikethrough: ansi.StylePrimitive{
+			CrossedOut: boolPtr(true),
+		},
+		Emph: ansi.StylePrimitive{
+			Color:  stringPtr(p.Text),
+			Italic: boolPtr(true),
+		},
+		Strong: ansi.StylePrimitive{
+			Color: stringPtr(p.Rose),
+			Bold:  boolPtr(true),
+		},
+		HorizontalRule: ansi.StylePrimitive{
+			Color:  stringPtr(p.Overlay),
+			Format: defaultHorizontalRule,
+		},
+		Item: ansi.StylePrimitive{
+			BlockPrefix: "• ",
+		},
+		Enumeration: ansi.StylePrimitive{
+			BlockPrefix: ". ",
+			Color:       stringPtr(p.Foam),
+		},
+		Task: ansi.StyleTask{
+			StylePrimitive: ansi.StylePrimitive{},
+			Ticked:         defaultTaskTickedPrefix,
+			Unticked:       defaultTaskUntickedPrefix,
+		},
+		Link: ansi.StylePrimitive{
+			Color:     stringPtr(p.Pine),
+			Underline: boolPtr(true),
+		},
+		LinkText: ansi.StylePrimitive{
+			Color: stringPtr(p.Iris),
+		},
+		Image: ansi.StylePrimitive{
+			Color:     stringPtr(p.Pine),
+			Underline: boolPtr(true),
+		},
+		ImageText: ansi.StylePrimitive{
+			Color:  stringPtr(p.Iris),
+			Format: defaultImageFormat,
+		},
+		Code: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color:           stringPtr(p.Gold),
+				BackgroundColor: stringPtr(p.Surface),
+			},
+		},
+		CodeBlock: ansi.StyleCodeBlock{
+			StyleBlock: ansi.StyleBlock{
+				StylePrimitive: ansi.StylePrimitive{
+					Color: stringPtr(p.Gold),
+				},
+				Margin: uintPtr(defaultMargin),
+			},
+			Chroma: &ansi.Chroma{
+				Text: ansi.StylePrimitive{
+					Color: stringPtr(p.Text),
+				},
+				Error: ansi.StylePrimitive{
+					Color:           stringPtr(p.Text),
+					BackgroundColor: stringPtr(p.Love),
+				},
+				Comment: ansi.StylePrimitive{
+					Color: stringPtr(p.Muted),
+				},
+				CommentPreproc: ansi.StylePrimitive{
+					Color: stringPtr(p.Iris),
+				},
+				Keyword: ansi.StylePrimitive{
+					Color: stringPtr(p.Pine),
+				},
+				KeywordReserved: ansi.StylePrimitive{
+					Color: stringPtr(p.Pine),
+				},
+				KeywordNamespace: ansi.StylePrimitive{
+					Color: stringPtr(p.Pine),
+				},
+				KeywordType: ansi.StylePrimitive{
+					Color: stringPtr(p.Foam),
+				},
+				Operator: ansi.StylePrimitive{
+					Color: stringPtr(p.Subtle),
+				},
+				Punctuation: ansi.StylePrimitive{
+					Color: stringPtr(p.Text),
+				},
+				Name: ansi.StylePrimitive{
+					Color: stringPtr(p.Text),
+				},
+				NameBuiltin: ansi.StylePrimitive{
+					Color: stringPtr(p.Foam),
+				},
+				NameTag: ansi.StylePrimitive{
+					Color: stringPtr(p.Iris),
+				},
+				NameAttribute: ansi.StylePrimitive{
+					Color: stringPtr(p.Foam),
+				},
+				NameClass: ansi.StylePrimitive{
+					Color: stringPtr(p.Foam),
+				},
+				NameConstant: ansi.StylePrimitive{
+					Color: stringPtr(p.Rose),
+				},
+				NameDecorator: ansi.StylePrimitive{
+					Color: stringPtr(p.Gold),
+				},
+				NameFunction: ansi.StylePrimitive{
+					Color: stringPtr(p.Rose),
+				},
+				LiteralNumber: ansi.StylePrimitive{
+					Color: stringPtr(p.Foam),
+				},
+				LiteralString: ansi.StylePrimitive{
+					Color: stringPtr(p.Gold),
+				},
+				LiteralStringEscape: ansi.StylePrimitive{
+					Color: stringPtr(p.Pine),
+				},
+				GenericDeleted: ansi.StylePrimitive{
+					Color: stringPtr(p.Love),
+				},
+				GenericEmph: ansi.StylePrimitive{
+					Color:  stringPtr(p.Gold),
+					Italic: boolPtr(true),
+				},
+				GenericInserted: ansi.StylePrimitive{
+					Color: stringPtr(p.Pine),
+				},
+				GenericStrong: ansi.StylePrimitive{
+					Color: stringPtr(p.Rose),
+					Bold:  boolPtr(true),
+				},
+				GenericSubheading: ansi.StylePrimitive{
+					Color: stringPtr(p.Iris),
+				},
+				Background: ansi.StylePrimitive{
+					BackgroundColor: stringPtr(p.Base),
+				},
+			},
+		},
+		Table: ansi.StyleTable{
+			StyleBlock: ansi.StyleBlock{
+				StylePrimitive: ansi.StylePrimitive{},
+			},
+		},
+		DefinitionList: ansi.StyleBlock{},
+		DefinitionTerm: ansi.StylePrimitive{},
+		DefinitionDescription: ansi.StylePrimitive{
+			BlockPrefix: defaultArrowBlockPrefix,
+		},
+		HTMLBlock: ansi.StyleBlock{},
+		HTMLSpan:  ansi.StyleBlock{},
+	}
+}

--- a/styles/rose-pine-dawn.go
+++ b/styles/rose-pine-dawn.go
@@ -1,0 +1,17 @@
+package styles
+
+// RosePineDawnStyleConfig is the Rosé Pine Dawn (light) style.
+var RosePineDawnStyleConfig = buildRosePineStyleConfig(rosePinePalette{
+	Base:    "#faf4ed",
+	Surface: "#fffaf3",
+	Overlay: "#f2e9e1",
+	Muted:   "#9893a5",
+	Subtle:  "#797593",
+	Text:    "#464261",
+	Love:    "#b4637a",
+	Gold:    "#ea9d34",
+	Rose:    "#d7827e",
+	Pine:    "#286983",
+	Foam:    "#56949f",
+	Iris:    "#907aa9",
+})

--- a/styles/rose-pine-dawn.json
+++ b/styles/rose-pine-dawn.json
@@ -1,0 +1,190 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "color": "#464261",
+    "margin": 2
+  },
+  "block_quote": {
+    "color": "#9893a5",
+    "italic": true,
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "color": "#464261",
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "#b4637a",
+    "bold": true
+  },
+  "h1": {
+    "prefix": "# "
+  },
+  "h2": {
+    "prefix": "## "
+  },
+  "h3": {
+    "prefix": "### "
+  },
+  "h4": {
+    "prefix": "#### "
+  },
+  "h5": {
+    "prefix": "##### "
+  },
+  "h6": {
+    "prefix": "###### "
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "color": "#464261",
+    "italic": true
+  },
+  "strong": {
+    "color": "#d7827e",
+    "bold": true
+  },
+  "hr": {
+    "color": "#f2e9e1",
+    "format": "\n--------\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". ",
+    "color": "#56949f"
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "#286983",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#907aa9"
+  },
+  "image": {
+    "color": "#286983",
+    "underline": true
+  },
+  "image_text": {
+    "color": "#907aa9",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "color": "#ea9d34",
+    "background_color": "#fffaf3"
+  },
+  "code_block": {
+    "color": "#ea9d34",
+    "margin": 2,
+    "chroma": {
+      "text": {
+        "color": "#464261"
+      },
+      "error": {
+        "color": "#464261",
+        "background_color": "#b4637a"
+      },
+      "comment": {
+        "color": "#9893a5"
+      },
+      "comment_preproc": {
+        "color": "#907aa9"
+      },
+      "keyword": {
+        "color": "#286983"
+      },
+      "keyword_reserved": {
+        "color": "#286983"
+      },
+      "keyword_namespace": {
+        "color": "#286983"
+      },
+      "keyword_type": {
+        "color": "#56949f"
+      },
+      "operator": {
+        "color": "#797593"
+      },
+      "punctuation": {
+        "color": "#464261"
+      },
+      "name": {
+        "color": "#464261"
+      },
+      "name_builtin": {
+        "color": "#56949f"
+      },
+      "name_tag": {
+        "color": "#907aa9"
+      },
+      "name_attribute": {
+        "color": "#56949f"
+      },
+      "name_class": {
+        "color": "#56949f"
+      },
+      "name_constant": {
+        "color": "#d7827e"
+      },
+      "name_decorator": {
+        "color": "#ea9d34"
+      },
+      "name_exception": {},
+      "name_function": {
+        "color": "#d7827e"
+      },
+      "name_other": {},
+      "literal": {},
+      "literal_number": {
+        "color": "#56949f"
+      },
+      "literal_date": {},
+      "literal_string": {
+        "color": "#ea9d34"
+      },
+      "literal_string_escape": {
+        "color": "#286983"
+      },
+      "generic_deleted": {
+        "color": "#b4637a"
+      },
+      "generic_emph": {
+        "color": "#ea9d34",
+        "italic": true
+      },
+      "generic_inserted": {
+        "color": "#286983"
+      },
+      "generic_strong": {
+        "color": "#d7827e",
+        "bold": true
+      },
+      "generic_subheading": {
+        "color": "#907aa9"
+      },
+      "background": {
+        "background_color": "#faf4ed"
+      }
+    }
+  },
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/styles/rose-pine.go
+++ b/styles/rose-pine.go
@@ -1,0 +1,17 @@
+package styles
+
+// RosePineStyleConfig is the Rosé Pine main (dark) style.
+var RosePineStyleConfig = buildRosePineStyleConfig(rosePinePalette{
+	Base:    "#191724",
+	Surface: "#1f1d2e",
+	Overlay: "#26233a",
+	Muted:   "#6e6a86",
+	Subtle:  "#908caa",
+	Text:    "#e0def4",
+	Love:    "#eb6f92",
+	Gold:    "#f6c177",
+	Rose:    "#ebbcba",
+	Pine:    "#31748f",
+	Foam:    "#9ccfd8",
+	Iris:    "#c4a7e7",
+})

--- a/styles/rose-pine.json
+++ b/styles/rose-pine.json
@@ -1,0 +1,190 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "color": "#e0def4",
+    "margin": 2
+  },
+  "block_quote": {
+    "color": "#6e6a86",
+    "italic": true,
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "color": "#e0def4",
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "#eb6f92",
+    "bold": true
+  },
+  "h1": {
+    "prefix": "# "
+  },
+  "h2": {
+    "prefix": "## "
+  },
+  "h3": {
+    "prefix": "### "
+  },
+  "h4": {
+    "prefix": "#### "
+  },
+  "h5": {
+    "prefix": "##### "
+  },
+  "h6": {
+    "prefix": "###### "
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "color": "#e0def4",
+    "italic": true
+  },
+  "strong": {
+    "color": "#ebbcba",
+    "bold": true
+  },
+  "hr": {
+    "color": "#26233a",
+    "format": "\n--------\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". ",
+    "color": "#9ccfd8"
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "#31748f",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#c4a7e7"
+  },
+  "image": {
+    "color": "#31748f",
+    "underline": true
+  },
+  "image_text": {
+    "color": "#c4a7e7",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "color": "#f6c177",
+    "background_color": "#1f1d2e"
+  },
+  "code_block": {
+    "color": "#f6c177",
+    "margin": 2,
+    "chroma": {
+      "text": {
+        "color": "#e0def4"
+      },
+      "error": {
+        "color": "#e0def4",
+        "background_color": "#eb6f92"
+      },
+      "comment": {
+        "color": "#6e6a86"
+      },
+      "comment_preproc": {
+        "color": "#c4a7e7"
+      },
+      "keyword": {
+        "color": "#31748f"
+      },
+      "keyword_reserved": {
+        "color": "#31748f"
+      },
+      "keyword_namespace": {
+        "color": "#31748f"
+      },
+      "keyword_type": {
+        "color": "#9ccfd8"
+      },
+      "operator": {
+        "color": "#908caa"
+      },
+      "punctuation": {
+        "color": "#e0def4"
+      },
+      "name": {
+        "color": "#e0def4"
+      },
+      "name_builtin": {
+        "color": "#9ccfd8"
+      },
+      "name_tag": {
+        "color": "#c4a7e7"
+      },
+      "name_attribute": {
+        "color": "#9ccfd8"
+      },
+      "name_class": {
+        "color": "#9ccfd8"
+      },
+      "name_constant": {
+        "color": "#ebbcba"
+      },
+      "name_decorator": {
+        "color": "#f6c177"
+      },
+      "name_exception": {},
+      "name_function": {
+        "color": "#ebbcba"
+      },
+      "name_other": {},
+      "literal": {},
+      "literal_number": {
+        "color": "#9ccfd8"
+      },
+      "literal_date": {},
+      "literal_string": {
+        "color": "#f6c177"
+      },
+      "literal_string_escape": {
+        "color": "#31748f"
+      },
+      "generic_deleted": {
+        "color": "#eb6f92"
+      },
+      "generic_emph": {
+        "color": "#f6c177",
+        "italic": true
+      },
+      "generic_inserted": {
+        "color": "#31748f"
+      },
+      "generic_strong": {
+        "color": "#ebbcba",
+        "bold": true
+      },
+      "generic_subheading": {
+        "color": "#c4a7e7"
+      },
+      "background": {
+        "background_color": "#191724"
+      }
+    }
+  },
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/styles/styles.go
+++ b/styles/styles.go
@@ -29,8 +29,10 @@ const (
 	AsciiStyle      = "ascii" //nolint: revive
 	DarkStyle       = "dark"
 	DraculaStyle    = "dracula"
-	TokyoNightStyle = "tokyo-night"
-	LightStyle      = "light"
+	TokyoNightStyle   = "tokyo-night"
+	RosePineStyle     = "rose-pine"
+	RosePineDawnStyle = "rose-pine-dawn"
+	LightStyle        = "light"
 	NoTTYStyle      = "notty"
 	PinkStyle       = "pink"
 )
@@ -681,8 +683,10 @@ var (
 		PinkStyle:  &PinkStyleConfig,
 
 		// Popular themes
-		DraculaStyle:    &DraculaStyleConfig,
-		TokyoNightStyle: &TokyoNightStyleConfig,
+		DraculaStyle:      &DraculaStyleConfig,
+		TokyoNightStyle:   &TokyoNightStyleConfig,
+		RosePineStyle:     &RosePineStyleConfig,
+		RosePineDawnStyle: &RosePineDawnStyleConfig,
 	}
 )
 


### PR DESCRIPTION
## Summary

- Adds `rose-pine` (main/dark) and `rose-pine-dawn` (light) Glamour styles using the official [Rosé Pine](https://rosepinetheme.com/) palette
- Follows the existing Dracula / Tokyo Night pattern: Go `StyleConfig` sources, generated JSON stylesheets, and gallery previews
- Styles are maintained upstream in [rose-pine-glamour](https://github.com/drluckyspin/rose-pine-glamour); this PR ports the two official variants

## Test plan

- [x] `go generate ./styles`
- [x] `go test ./...`
- [x] Generated `styles/rose-pine.json` and `styles/rose-pine-dawn.json`
- [x] Added gallery PNGs under `styles/gallery/`