### PR TITLE
fix(autolink): allow dots in repo names and reject invalid slugs

### DIFF
--- a/internal/autolink/autolink.go
+++ b/internal/autolink/autolink.go
@@ -12,33 +12,43 @@ type pattern struct {
 	yield   func(m []string) string
 }
 
+const (
+	// owner matches a GitHub account name (letters, digits and hyphens).
+	owner = `[\w-]+`
+	// repo matches a GitHub repository name, which may additionally contain
+	// dots (e.g. next.js).
+	repo = `[\w.-]+`
+	// sha matches a Git commit hash.
+	sha = `[A-Za-z0-9]{7,}`
+)
+
 var patterns = []pattern{
 	{
-		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/(issues?|pulls?|discussions?)/([0-9]+)$`),
+		regexp.MustCompile(`^https?://github\.com/(` + owner + `)/(` + repo + `)/(issues?|pulls?|discussions?)/([0-9]+)$`),
 		func(m []string) string { return fmt.Sprintf("%s/%s#%s", m[1], m[2], m[4]) },
 	},
 	{
-		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/(issues?|pulls?|discussions?)/([0-9]+)#issuecomment-[0-9]+$`),
+		regexp.MustCompile(`^https?://github\.com/(` + owner + `)/(` + repo + `)/(issues?|pulls?|discussions?)/([0-9]+)#issuecomment-[0-9]+$`),
 		func(m []string) string { return fmt.Sprintf("%s/%s#%s (comment)", m[1], m[2], m[4]) },
 	},
 	{
-		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/pulls?/([0-9]+)#discussion_r[0-9]+$`),
+		regexp.MustCompile(`^https?://github\.com/(` + owner + `)/(` + repo + `)/pulls?/([0-9]+)#discussion_r[0-9]+$`),
 		func(m []string) string { return fmt.Sprintf("%s/%s#%s (comment)", m[1], m[2], m[3]) },
 	},
 	{
-		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/pulls?/([0-9]+)#pullrequestreview-[0-9]+$`),
+		regexp.MustCompile(`^https?://github\.com/(` + owner + `)/(` + repo + `)/pulls?/([0-9]+)#pullrequestreview-[0-9]+$`),
 		func(m []string) string { return fmt.Sprintf("%s/%s#%s (review)", m[1], m[2], m[3]) },
 	},
 	{
-		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/discussions/([0-9]+)#discussioncomment-[0-9]+$`),
+		regexp.MustCompile(`^https?://github\.com/(` + owner + `)/(` + repo + `)/discussions/([0-9]+)#discussioncomment-[0-9]+$`),
 		func(m []string) string { return fmt.Sprintf("%s/%s#%s (comment)", m[1], m[2], m[3]) },
 	},
 	{
-		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/commit/([A-z0-9]{7,})(#.*)?$`),
+		regexp.MustCompile(`^https?://github\.com/(` + owner + `)/(` + repo + `)/commit/(` + sha + `)(#.*)?$`),
 		func(m []string) string { return fmt.Sprintf("%s/%s@%s", m[1], m[2], m[3][:7]) },
 	},
 	{
-		regexp.MustCompile(`^https?://github\.com/([A-z0-9_-]+)/([A-z0-9_-]+)/pulls?/[0-9]+/commits/([A-z0-9]{7,})(#.*)?$`),
+		regexp.MustCompile(`^https?://github\.com/(` + owner + `)/(` + repo + `)/pulls?/[0-9]+/commits/(` + sha + `)(#.*)?$`),
 		func(m []string) string { return fmt.Sprintf("%s/%s@%s", m[1], m[2], m[3][:7]) },
 	},
 }

--- a/internal/autolink/autolink_test.go
+++ b/internal/autolink/autolink_test.go
@@ -38,6 +38,10 @@ func TestDetect(t *testing.T) {
 		{"https://github.com/owner/repo/commit/abcdefghijklmnopqrsxyz#diff-123", "owner/repo@abcdefg"},
 		{"https://github.com/owner/repo/pull/123/commits/abcdefghijklmnopqrsxyz#diff-123", "owner/repo@abcdefg"},
 		{"https://github.com/owner/repo/pulls/123/commits/abcdefghijklmnopqrsxyz#diff-123", "owner/repo@abcdefg"},
+
+		// Repository names may contain dots (e.g. vercel/next.js).
+		{"https://github.com/vercel/next.js/issues/123", "vercel/next.js#123"},
+		{"https://github.com/owner/repo.github.io/pull/5", "owner/repo.github.io#5"},
 	}
 	for _, test := range tests {
 		t.Run(test.url, func(t *testing.T) {
@@ -47,6 +51,25 @@ func TestDetect(t *testing.T) {
 			}
 			if result != test.expected {
 				t.Errorf("expected %s, got %s", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestDetectRejectsInvalid(t *testing.T) {
+	// Characters that are not valid in GitHub owner or repository names must
+	// not be treated as part of the slug. These previously matched because the
+	// pattern used the `A-z` range, which also covers punctuation such as
+	// `[ \ ] ^ ` `.
+	urls := []string{
+		"https://github.com/ow^ner/repo/issues/1",
+		"https://github.com/owner/re]po/issues/1",
+		"https://github.com/owner/repo/commit/abcde`fg",
+	}
+	for _, u := range urls {
+		t.Run(u, func(t *testing.T) {
+			if result, ok := autolink.Detect(u); ok {
+				t.Errorf("expected %q to be rejected, got %q", u, result)
 			}
 		})
 	}


### PR DESCRIPTION
The link-shortening patterns used the character class `[A-z0-9_-]`. The `A-z` range also matches the ASCII punctuation between `Z` and `a` (`[ \ ] ^ ` `), so URLs with those characters in the owner/repo were wrongly shortened; and the class excluded `.`, so links to repos whose names contain a dot - like `github.com/vercel/next.js/issues/123` - were never shortened. This switches to `\w`-based classes and allows dots in the repository segment.
