### PR TITLE
fix: expand tilde in WithStylePath style file paths

### DIFF
--- a/glamour.go
+++ b/glamour.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/yuin/goldmark"
 	emoji "github.com/yuin/goldmark-emoji"
@@ -130,7 +132,12 @@ func WithStylePath(stylePath string) TermRendererOption {
 	return func(tr *TermRenderer) error {
 		styles, err := getDefaultStyle(stylePath)
 		if err != nil {
-			jsonBytes, err := os.ReadFile(stylePath)
+			expandedPath, err := expandTildePath(stylePath)
+			if err != nil {
+				return fmt.Errorf("glamour: error expanding style path: %w", err)
+			}
+
+			jsonBytes, err := os.ReadFile(expandedPath)
 			if err != nil {
 				return fmt.Errorf("glamour: error reading file: %w", err)
 			}
@@ -140,6 +147,27 @@ func WithStylePath(stylePath string) TermRendererOption {
 		tr.ansiOptions.Styles = *styles
 		return nil
 	}
+}
+
+// expandTildePath expands a leading "~" or "~/" in path to the current
+// user's home directory. A shell does this automatically for an unquoted
+// command-line argument, which is why the same style path works with the
+// "-s" flag but not when read verbatim out of a config file. Paths that
+// don't begin with "~" are returned unchanged.
+func expandTildePath(path string) (string, error) {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not determine home directory: %w", err)
+	}
+
+	if path == "~" {
+		return home, nil
+	}
+	return filepath.Join(home, path[2:]), nil
 }
 
 // WithStyles sets a TermRenderer's styles.

--- a/glamour_test.go
+++ b/glamour_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -168,6 +169,50 @@ func TestCustomStyle(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestWithStylePathExpandsTilde(t *testing.T) {
+	// A shell expands an unquoted "~" argument before the program ever sees
+	// it, which is why the same style path works with "-s" on the command
+	// line but not when read verbatim out of a config file (e.g. glow.yml).
+	// Fake HOME/USERPROFILE so this is portable across OSes without touching
+	// the real home directory.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	styleBytes, err := os.ReadFile("testdata/custom.style")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "custom.style"), styleBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	direct, err := NewTermRenderer(WithStylePath("testdata/custom.style"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tilde, err := NewTermRenderer(WithStylePath("~/custom.style"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text, err := os.ReadFile("testdata/example.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := direct.RenderBytes(text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := tilde.RenderBytes(text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(want, got) {
+		t.Error("style loaded via a tilde-prefixed path did not match the same style loaded directly")
 	}
 }
 


### PR DESCRIPTION
WithStylePath passed stylePath straight to os.ReadFile, so a path like "~/.config/glow/styles/tokyo-night.json" only worked when a shell had already expanded the tilde before the program saw it -- which happens for a "-s" command-line flag but not for the same string read verbatim out of a config file such as glow.yml, where it fails with "no such file or directory".

Added expandTildePath, applied before the read, handling the "~" and "~/..." forms (matching what a shell expands for an unquoted argument). Other paths are returned unchanged.

Fixes #545

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
