### PR TITLE
feat: suppress visible URL when link style has Conceal=true

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -244,12 +244,13 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 			}
 		}
 
+		skipHref := isFooterLinks || (ctx.options.Styles.Link.Conceal != nil && *ctx.options.Styles.Link.Conceal)
 		return Element{
 			Renderer: &LinkElement{
 				BaseURL:  ctx.options.BaseURL,
 				URL:      string(n.Destination),
 				Children: children,
-				SkipHref: isFooterLinks,
+				SkipHref: skipHref,
 			},
 		}
 	case ast.KindAutoLink:

--- a/glamour_test.go
+++ b/glamour_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/glamour/v2/ansi"
 	"charm.land/glamour/v2/styles"
 	"github.com/charmbracelet/x/exp/golden"
 )
@@ -322,4 +323,109 @@ func TestWithChromaFormatterCustom(t *testing.T) {
 	}
 
 	golden.RequireEqual(t, []byte(b))
+}
+
+func TestLinkConcealSkipHref(t *testing.T) {
+	input := "[click here](https://example.com)"
+
+	t.Run("conceal true suppresses visible URL", func(t *testing.T) {
+		conceal := true
+		style := ansi.StyleConfig{
+			Link: ansi.StylePrimitive{
+				Conceal: &conceal,
+			},
+		}
+		r, err := NewTermRenderer(
+			WithStyles(style),
+			WithWordWrap(80),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		out, err := r.Render(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The link text "click here" should be present
+		if !strings.Contains(out, "click here") {
+			t.Errorf("Expected link text 'click here' in output, got: %q", out)
+		}
+
+		// The URL should NOT appear as visible text (strip ANSI/OSC sequences first)
+		stripped := stripOSC8(out)
+		if strings.Contains(stripped, "https://example.com") {
+			t.Errorf("Expected URL to be suppressed with Conceal=true, but found it in output: %q", stripped)
+		}
+	})
+
+	t.Run("conceal false shows visible URL", func(t *testing.T) {
+		conceal := false
+		style := ansi.StyleConfig{
+			Link: ansi.StylePrimitive{
+				Conceal: &conceal,
+			},
+		}
+		r, err := NewTermRenderer(
+			WithStyles(style),
+			WithWordWrap(80),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		out, err := r.Render(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Both the link text and the URL should be present
+		if !strings.Contains(out, "click here") {
+			t.Errorf("Expected link text 'click here' in output, got: %q", out)
+		}
+
+		stripped := stripOSC8(out)
+		if !strings.Contains(stripped, "https://example.com") {
+			t.Errorf("Expected URL to be visible with Conceal=false, but not found in output: %q", stripped)
+		}
+	})
+
+	t.Run("conceal nil shows visible URL", func(t *testing.T) {
+		style := ansi.StyleConfig{
+			Link: ansi.StylePrimitive{
+				// Conceal not set (nil)
+			},
+		}
+		r, err := NewTermRenderer(
+			WithStyles(style),
+			WithWordWrap(80),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		out, err := r.Render(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Both the link text and the URL should be present
+		if !strings.Contains(out, "click here") {
+			t.Errorf("Expected link text 'click here' in output, got: %q", out)
+		}
+
+		stripped := stripOSC8(out)
+		if !strings.Contains(stripped, "https://example.com") {
+			t.Errorf("Expected URL to be visible with Conceal=nil, but not found in output: %q", stripped)
+		}
+	})
+}
+
+// stripOSC8 removes OSC 8 hyperlink escape sequences from the string,
+// leaving only the visible text content.
+func stripOSC8(s string) string {
+	// OSC 8 format: \x1b]8;params;uri\x1b\\ or \x1b]8;params;uri\x07
+	re := regexp.MustCompile(`\x1b\]8;[^\x1b\x07]*(?:\x1b\\|\x07)`)
+	return re.ReplaceAllString(s, "")
 }


### PR DESCRIPTION
## Summary

When the link style has `"conceal": true` in the style JSON, suppress the visible URL text after the link text. The link text itself remains wrapped with OSC 8 hyperlink sequences, so it's clickable in terminals that support it.

**What:** When `Styles.Link.Conceal` is `true`, set `SkipHref=true` on the `LinkElement`, suppressing the rendered URL while preserving the hyperlink wrapping.

**Why:** Terminals that support OSC 8 hyperlinks don't need the URL printed as visible text — the link text itself is already clickable. This gives users a way to opt into cleaner output by setting `"conceal": true` on the link style.

**How:** Reuses the existing `SkipHref` mechanism that's already used for table footer links. A one-line change in `ansi/elements.go` checks `ctx.options.Styles.Link.Conceal` alongside the existing `isFooterLinks` condition.

## Changes

- `ansi/elements.go`: Check `Styles.Link.Conceal` when determining `SkipHref` for regular links
- `glamour_test.go`: Add `TestLinkConcealSkipHref` with three sub-tests:
  - `Conceal=true` suppresses the visible URL
  - `Conceal=false` shows the URL (existing behavior)
  - `Conceal=nil` shows the URL (existing behavior)

## Test plan

- [x] `go test ./...` passes
- [x] New test verifies Conceal=true suppresses URL text
- [x] New test verifies Conceal=false/nil preserves existing behavior
- [x] No golden file changes (existing styles don't set Conceal on Link)

## Manual Testing

To verify this change manually with the `glow` CLI:

### 1. Create a test style JSON

```bash
cat > /tmp/test-style.json << 'STYLE'
{
  "document": {
    "margin": 2
  },
  "link": {
    "conceal": true
  },
  "link_text": {
    "color": "39",
    "bold": true
  }
}
STYLE
```

### 2. Create a sample markdown file

```bash
cat > /tmp/test.md << 'MD'
# Link Conceal Demo

Check out [Example Site](https://example.com) for more info.

Read the [Go documentation](https://go.dev/doc) to get started.

Here is an [inline link](https://example.org/path) in a sentence.
MD
```

### 3. Render with conceal enabled

```bash
glow -s /tmp/test-style.json /tmp/test.md
```

**Expected output** (conceal = true):

```
  # Link Conceal Demo

  Check out Example Site for more info.

  Read the Go documentation to get started.

  Here is an inline link in a sentence.
```

- Link text ("Example Site", "Go documentation", "inline link") is rendered in bold cyan (color 39)
- URLs are **not** printed as visible text
- OSC 8 hyperlink escape sequences wrap the link text, making it clickable in terminals that support it (iTerm2, WezTerm, Windows Terminal, GNOME Terminal, etc.)
- You can verify OSC 8 sequences are present by piping through `cat -v` or `hexdump`

### 4. Compare: render WITHOUT conceal (default behavior)

Remove `"conceal": true` from the style:

```bash
cat > /tmp/test-style-default.json << 'STYLE'
{
  "document": {
    "margin": 2
  },
  "link_text": {
    "color": "39",
    "bold": true
  }
}
STYLE

glow -s /tmp/test-style-default.json /tmp/test.md
```

**Expected output** (default, no conceal):

```
  # Link Conceal Demo

  Check out Example Site (https://example.com) for more info.

  Read the Go documentation (https://go.dev/doc) to get started.

  Here is an inline link (https://example.org/path) in a sentence.
```

- Both the link text AND the URL are printed as visible text
- This is the existing/default behavior preserved when `conceal` is absent or `false`

### 5. Verify OSC 8 escape sequences

To confirm the hyperlink escapes are still emitted even when the URL is concealed:

```bash
glow -s /tmp/test-style.json /tmp/test.md | cat -v
```

You should see sequences like `^[]8;;https://example.com^[\` before the link text and `^[]8;;^[\` after it, confirming the terminal hyperlink is intact despite the URL not being shown as visible text.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
