### PR TITLE
perf(ansi): stop rebuilding styles and decoding runes per cell

### DIFF
--- a/ansi/baseelement.go
+++ b/ansi/baseelement.go
@@ -41,6 +41,22 @@ func renderText(w io.Writer, rules StylePrimitive, s string) (int, error) { //no
 		return 0, nil
 	}
 
+	n, err := io.WriteString(w, styleText(rules, s))
+	if err != nil {
+		return n, fmt.Errorf("glamour: error writing to writer: %w", err)
+	}
+	return n, nil
+}
+
+// styleText applies rules to s and returns the styled string. Split out
+// of renderText so callers that write the same styled text repeatedly
+// (padding and indent runs, which emit one cell at a time) can build it
+// once instead of rederiving the style on every cell.
+func styleText(rules StylePrimitive, s string) string {
+	if len(s) == 0 {
+		return ""
+	}
+
 	// XXX: We're using [ansi.Style] instead of [lipgloss.Style] because
 	// Lip Gloss has a weird bug where it adds spaces when rendering joined
 	// strings. Needs further investigation.
@@ -79,12 +95,7 @@ func renderText(w io.Writer, rules StylePrimitive, s string) (int, error) { //no
 		style = style.Blink(true)
 	}
 
-	n, err := io.WriteString(w, style.Styled(s))
-	if err != nil {
-		return n, fmt.Errorf("glamour: error writing to writer: %w", err)
-	}
-
-	return n, nil
+	return style.Styled(s)
 }
 
 // StyleOverrideRender renders a BaseElement with an overridden style.

--- a/ansi/margin.go
+++ b/ansi/margin.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"unicode/utf8"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -96,39 +95,49 @@ func NewPaddingWriter(w io.Writer, padding int, padFunc PaddingFunc) *PaddingWri
 
 // Write writes to the padding writer.
 func (w *PaddingWriter) Write(p []byte) (int, error) {
-	// Use UTF-8 aware iteration to properly handle multi-byte characters (e.g., CJK)
-	for i := 0; i < len(p); {
-		r, size := utf8.DecodeRune(p[i:])
-		if r == '\n' { //nolint:nestif
-			line := w.cache.String()
-			linew := ansi.StringWidth(line)
-			if w.Padding > 0 && linew < w.Padding {
-				if w.PadFunc != nil {
-					for n := 0; n < w.Padding-linew; n++ {
-						w.PadFunc(w.w)
-					}
-				} else {
-					_, err := io.WriteString(w.w, strings.Repeat(" ", w.Padding-linew))
-					if err != nil {
-						return 0, fmt.Errorf("glamour: error writing padding: %w", err)
-					}
+	// Lines are forwarded whole rather than a rune at a time: only a
+	// newline needs handling, and a newline byte can never appear inside
+	// a multi-byte UTF-8 sequence, so scanning for it is UTF-8 safe
+	// without decoding.
+	total := len(p)
+	for len(p) > 0 {
+		i := bytes.IndexByte(p, '\n')
+		if i < 0 {
+			w.cache.Write(p)
+			if _, err := w.w.Write(p); err != nil {
+				return 0, fmt.Errorf("glamour: error writing bytes: %w", err)
+			}
+			break
+		}
+
+		if i > 0 {
+			w.cache.Write(p[:i])
+			if _, err := w.w.Write(p[:i]); err != nil {
+				return 0, fmt.Errorf("glamour: error writing bytes: %w", err)
+			}
+		}
+
+		linew := ansi.StringWidth(w.cache.String())
+		if w.Padding > 0 && linew < w.Padding {
+			if w.PadFunc != nil {
+				for n := 0; n < w.Padding-linew; n++ {
+					w.PadFunc(w.w)
+				}
+			} else {
+				if _, err := io.WriteString(w.w, strings.Repeat(" ", w.Padding-linew)); err != nil {
+					return 0, fmt.Errorf("glamour: error writing padding: %w", err)
 				}
 			}
-			w.cache.Reset()
-		} else {
-			// Write complete UTF-8 character bytes to cache
-			w.cache.Write(p[i : i+size])
 		}
+		w.cache.Reset()
 
-		// Write complete UTF-8 character bytes to output
-		_, err := w.w.Write(p[i : i+size])
-		if err != nil {
+		if _, err := w.w.Write(p[i : i+1]); err != nil {
 			return 0, fmt.Errorf("glamour: error writing bytes: %w", err)
 		}
-		i += size
+		p = p[i+1:]
 	}
 
-	return len(p), nil
+	return total, nil
 }
 
 // Close closes the [PaddingWriter].
@@ -184,9 +193,12 @@ func (w *IndentWriter) restorePen() {
 
 // Write writes to the indentation writer.
 func (w *IndentWriter) Write(p []byte) (int, error) {
-	// Use UTF-8 aware iteration to properly handle multi-byte characters (e.g., CJK)
-	for i := 0; i < len(p); {
-		r, size := utf8.DecodeRune(p[i:])
+	// Indentation is only ever emitted at the start of a line, so the
+	// rest of the line goes downstream in one Write. A newline byte can
+	// never appear inside a multi-byte UTF-8 sequence, so scanning for
+	// it is UTF-8 safe without decoding.
+	total := len(p)
+	for len(p) > 0 {
 		if !w.skipIndent {
 			w.resetPen()
 			if w.IndentFunc != nil {
@@ -194,8 +206,7 @@ func (w *IndentWriter) Write(p []byte) (int, error) {
 					w.IndentFunc(w.pw)
 				}
 			} else {
-				_, err := io.WriteString(w.pw, strings.Repeat(" ", w.Indent))
-				if err != nil {
+				if _, err := io.WriteString(w.pw, strings.Repeat(" ", w.Indent)); err != nil {
 					return 0, fmt.Errorf("glamour: error writing indentation: %w", err)
 				}
 			}
@@ -204,19 +215,21 @@ func (w *IndentWriter) Write(p []byte) (int, error) {
 			w.restorePen()
 		}
 
-		if r == '\n' {
+		run := p
+		i := bytes.IndexByte(p, '\n')
+		if i < 0 {
+			p = nil
+		} else {
+			run, p = p[:i+1], p[i+1:]
 			w.skipIndent = false
 		}
 
-		// Write complete UTF-8 character bytes to output
-		_, err := w.pw.Write(p[i : i+size])
-		if err != nil {
+		if _, err := w.pw.Write(run); err != nil {
 			return 0, fmt.Errorf("glamour: error writing bytes: %w", err)
 		}
-		i += size
 	}
 
-	return len(p), nil
+	return total, nil
 }
 
 // Close closes the [IndentWriter].

--- a/ansi/margin.go
+++ b/ansi/margin.go
@@ -14,7 +14,6 @@ import (
 // MarginWriter is a Writer that applies indentation and padding around
 // whatever you write to it.
 type MarginWriter struct {
-	w  io.Writer
 	iw *IndentWriter
 }
 
@@ -47,10 +46,7 @@ func NewMarginWriter(ctx RenderContext, w io.Writer, rules StyleBlock) *MarginWr
 		_, _ = io.WriteString(w, indentCell)
 	})
 
-	return &MarginWriter{
-		w:  lipgloss.NewWrapWriter(w),
-		iw: iw,
-	}
+	return &MarginWriter{iw: iw}
 }
 
 // Write writes to the margin writer and implements [io.Writer].
@@ -64,12 +60,7 @@ func (w *MarginWriter) Write(b []byte) (int, error) {
 
 // Close closes the [MarginWriter].
 func (w *MarginWriter) Close() error {
-	var werr error
-	if c, ok := w.w.(io.WriteCloser); ok {
-		werr = c.Close()
-	}
-
-	return errors.Join(werr, w.iw.Close())
+	return w.iw.Close()
 }
 
 // PaddingFunc is a function that applies padding around whatever you write to it.

--- a/ansi/margin.go
+++ b/ansi/margin.go
@@ -32,16 +32,20 @@ func NewMarginWriter(ctx RenderContext, w io.Writer, rules StyleBlock) *MarginWr
 		margin = *rules.Margin
 	}
 
+	// The styled cell is invariant, so build it once here rather than
+	// rederiving the style on every padding column of every line.
+	padCell := styleText(rules.StylePrimitive, " ")
 	pw := NewPaddingWriter(w, int(bs.Width(ctx)), func(_ io.Writer) {
-		_, _ = renderText(w, rules.StylePrimitive, " ")
+		_, _ = io.WriteString(w, padCell)
 	})
 
 	ic := " "
 	if rules.IndentToken != nil {
 		ic = *rules.IndentToken
 	}
+	indentCell := styleText(bs.Parent().Style.StylePrimitive, ic)
 	iw := NewIndentWriter(pw, int(indentation+margin), func(_ io.Writer) {
-		_, _ = renderText(w, bs.Parent().Style.StylePrimitive, ic)
+		_, _ = io.WriteString(w, indentCell)
 	})
 
 	return &MarginWriter{

--- a/glamour.go
+++ b/glamour.go
@@ -282,6 +282,10 @@ func (tr *TermRenderer) Render(in string) (string, error) {
 // RenderBytes returns the markdown rendered into a byte slice.
 func (tr *TermRenderer) RenderBytes(in []byte) ([]byte, error) {
 	var buf bytes.Buffer
+	// Styled output runs a few times the size of its markdown source, so
+	// size the buffer up front rather than letting it double its way
+	// there and recopy the document at every step.
+	buf.Grow(len(in) * 3)
 	err := tr.md.Convert(in, &buf)
 	return buf.Bytes(), err
 }

--- a/render_bench_test.go
+++ b/render_bench_test.go
@@ -1,0 +1,49 @@
+package glamour
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func proseDoc(paragraphs int) string {
+	var b strings.Builder
+	for i := range paragraphs {
+		fmt.Fprintf(&b, "Considering angle %d of the question in some detail, the constraint holds for every branch here and the wrapping needs to run across several lines to be representative.\n\n", i)
+	}
+	return b.String()
+}
+
+func mixedDoc(n int) string {
+	var b strings.Builder
+	for i := range n {
+		fmt.Fprintf(&b, "## Heading %d\n\nSome **bold** and _italic_ prose with `code` and a [link](https://example.com) that wraps.\n\n- item one\n- item two\n\n```go\nfunc f() { return }\n```\n\n", i)
+	}
+	return b.String()
+}
+
+func benchRender(b *testing.B, doc string) {
+	r, err := NewTermRenderer(WithStandardStyle("dark"), WithWordWrap(120))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(int64(len(doc)))
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := r.Render(doc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRenderProse(b *testing.B) {
+	for _, n := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("paras=%d", n), func(b *testing.B) { benchRender(b, proseDoc(n)) })
+	}
+}
+
+func BenchmarkRenderMixed(b *testing.B) {
+	for _, n := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("blocks=%d", n), func(b *testing.B) { benchRender(b, mixedDoc(n)) })
+	}
+}


### PR DESCRIPTION
Four changes to the render path. No API change; all of it is internal.

### 1. Build the padding and indent cells once

`PaddingWriter` and `IndentWriter` emit one cell at a time, and their funcs called `renderText` for each one:

```go
pw := NewPaddingWriter(w, int(bs.Width(ctx)), func(_ io.Writer) {
    _, _ = renderText(w, rules.StylePrimitive, " ")
})
```

So for every padding column of every line we re-derived the whole `ansi.Style`: parse the colour, format the RGB through `strconv`, append to a slice, join — to produce one styled space. The style is invariant. Profiling put **99.24%** of the remaining allocations in that single closure. Split `styleText` out of `renderText` and hoist the cell.

### 2. Forward whole lines through the indent and padding writers

Both walked their input a rune at a time, decoding each one and calling the downstream writer for it. Indentation is only ever emitted at the start of a line and padding only at the end, so the rest of the line goes downstream in one `Write`.

The rune decoding was there to be "UTF-8 aware", but a newline byte can never appear inside a multi-byte UTF-8 sequence, so scanning for it with `IndexByte` needs no decoding at all.

### 3. Size the render buffer

`RenderBytes` let its output buffer double its way up from zero, recopying the document at every step. Styled output runs a few times the size of its source, so size it once.

### 4. Drop the unused margin wrap writer

`MarginWriter` built a `WrapWriter` it never wrote to, only closed — taking a parser from the pool and two closures per block element to do nothing.

### Numbers

Rendering a 17 KB markdown document. This PR alone, against Lip Gloss `main`:

| | before | after |
|---|---|---|
| prose | 498,475 allocs | 426,897 |
| mixed markdown | 1,982,828 allocs | 1,621,732 |

Modest on its own, because the per-byte allocation in `lipgloss.WrapWriter` dominates and hides it. With charmbracelet/lipgloss#737, which removes that, the two changes unmask each other:

| | before | with both |
|---|---|---|
| prose, allocations | 498,475 | **8,291** (60x fewer) |
| prose, time | 18.6 ms | **8.29 ms** (2.24x) |
| mixed markdown, allocations | 1,982,828 | **81,346** (24x fewer) |

That is roughly 29 allocations per input byte down to well under one. Worth reviewing the two together.

### Correctness

Output is unchanged byte for byte, across 6 styles x 5 widths x 5 document types — 6.3 MB of output, `cmp`-identical against `main` — including CJK, emoji ZWJ sequences, regional-indicator flags and combining marks. That last part mattered for change 2: the comment justifying the rune decoding named CJK specifically, so I tested the claim rather than the code.

### Benchmarks

There were none, so there was nothing to point at when this path regressed. Added `render_bench_test.go`.

### Context

Found while chasing charmbracelet/crush#3162, where a user's terminal consumed 50 GB of heap streaming a long reasoning trace through Glamour.
