### PR TITLE
fix(security): control safe entries

### DIFF
--- a/ansi/context.go
+++ b/ansi/context.go
@@ -11,8 +11,8 @@ import (
 
 var htmlNumericReference = regexp.MustCompile(`&#(?:[xX][0-9A-Fa-f]+|[0-9]+);?`)
 
-func unescapeHTML(s string) string {
-	s = htmlNumericReference.ReplaceAllStringFunc(s, func(reference string) string {
+func protectHTMLControlReferences(s string) string {
+	return htmlNumericReference.ReplaceAllStringFunc(s, func(reference string) string {
 		if strings.ContainsFunc(html.UnescapeString(reference), func(r rune) bool {
 			return r != '\n' && r != '\t' && unicode.IsControl(r)
 		}) {
@@ -20,7 +20,10 @@ func unescapeHTML(s string) string {
 		}
 		return reference
 	})
-	return html.UnescapeString(s)
+}
+
+func unescapeHTML(s string) string {
+	return html.UnescapeString(protectHTMLControlReferences(s))
 }
 
 // RenderContext holds the current rendering options and state.
@@ -45,6 +48,7 @@ func NewRenderContext(options Options) RenderContext {
 
 // SanitizeHTML sanitizes HTML content.
 func (ctx RenderContext) SanitizeHTML(s string, trimSpaces bool) string {
+	s = protectHTMLControlReferences(s)
 	s = ctx.stripper.Sanitize(s)
 	if trimSpaces {
 		s = strings.TrimSpace(s)

--- a/ansi/context.go
+++ b/ansi/context.go
@@ -2,10 +2,26 @@ package ansi
 
 import (
 	"html"
+	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/microcosm-cc/bluemonday"
 )
+
+var htmlNumericReference = regexp.MustCompile(`&#(?:[xX][0-9A-Fa-f]+|[0-9]+);?`)
+
+func unescapeHTML(s string) string {
+	s = htmlNumericReference.ReplaceAllStringFunc(s, func(reference string) string {
+		if strings.ContainsFunc(html.UnescapeString(reference), func(r rune) bool {
+			return r != '\n' && r != '\t' && unicode.IsControl(r)
+		}) {
+			return "&amp;" + reference[1:]
+		}
+		return reference
+	})
+	return html.UnescapeString(s)
+}
 
 // RenderContext holds the current rendering options and state.
 type RenderContext struct {
@@ -34,5 +50,5 @@ func (ctx RenderContext) SanitizeHTML(s string, trimSpaces bool) string {
 		s = strings.TrimSpace(s)
 	}
 
-	return html.UnescapeString(s)
+	return unescapeHTML(s)
 }

--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -3,7 +3,6 @@ package ansi
 import (
 	"bytes"
 	"fmt"
-	"html"
 	"io"
 	"strings"
 
@@ -177,7 +176,7 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		}
 		return Element{
 			Renderer: &BaseElement{
-				Token: html.UnescapeString(s),
+				Token: unescapeHTML(s),
 				Style: ctx.options.Styles.Text,
 			},
 		}
@@ -204,7 +203,7 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 
 		return Element{
 			Renderer: &BaseElement{
-				Token: html.UnescapeString(s),
+				Token: unescapeHTML(s),
 				Style: style,
 			},
 		}
@@ -366,7 +365,7 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 		s := string(n.Text(source)) //nolint: staticcheck
 		return Element{
 			Renderer: &CodeSpanElement{
-				Text:  html.UnescapeString(s),
+				Text:  unescapeHTML(s),
 				Style: cascadeStyle(ctx.blockStack.Current().Style, ctx.options.Styles.Code, false).StylePrimitive,
 			},
 		}

--- a/ansi/renderer_test.go
+++ b/ansi/renderer_test.go
@@ -154,10 +154,49 @@ func TestRendererDoesNotDecodeControlEntitiesAcrossNodes(t *testing.T) {
 	if err := md.Convert([]byte("~~&**#27;**[31mFAKE~~"), &buf); err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(buf.String(), "\x1b[31m") {
-		t.Fatalf("rendered source terminal control: %q", buf.String())
+	if got := buf.String(); got != "&#27;[31mFAKE\n" {
+		t.Fatalf("unexpected render: %q", got)
 	}
-	if !strings.Contains(buf.String(), "&#27;[31mFAKE") {
-		t.Fatalf("control reference was not preserved: %q", buf.String())
+}
+
+func TestUnescapeHTMLNumericReferencePolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"decimal escape", "&#27;", "&#27;"},
+		{"hex escape", "&#x1b;", "&#x1b;"},
+		{"uppercase hex escape", "&#X1B;", "&#X1B;"},
+		{"semicolonless decimal escape", "&#27", "&#27"},
+		{"semicolonless hex escape", "&#x1b", "&#x1b"},
+		{"carriage return", "&#13;", "&#13;"},
+		{"delete", "&#127;", "&#127;"},
+		{"C1 control", "&#129;", "&#129;"},
+		{"tab", "&#9;", "\t"},
+		{"newline", "&#10;", "\n"},
+		{"printable", "&#65;", "A"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := unescapeHTML(test.in); got != test.want {
+				t.Fatalf("unescapeHTML(%q) = %q, want %q", test.in, got, test.want)
+			}
+		})
+	}
+}
+
+func TestRendererDoesNotDecodeControlEntitiesInHTMLBlock(t *testing.T) {
+	md := goldmark.New()
+	md.SetRenderer(renderer.NewRenderer(
+		renderer.WithNodeRenderers(util.Prioritized(NewRenderer(Options{}), 1000))))
+
+	var buf bytes.Buffer
+	if err := md.Convert([]byte("<div>\n&#27;[31mFAKE\n</div>\n"), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "&#27;[31mFAKE" {
+		t.Fatalf("unexpected render: %q", got)
 	}
 }

--- a/ansi/renderer_test.go
+++ b/ansi/renderer_test.go
@@ -144,3 +144,20 @@ func TestRendererIssues(t *testing.T) {
 		})
 	}
 }
+
+func TestRendererDoesNotDecodeControlEntitiesAcrossNodes(t *testing.T) {
+	md := goldmark.New(goldmark.WithExtensions(extension.GFM))
+	md.SetRenderer(renderer.NewRenderer(
+		renderer.WithNodeRenderers(util.Prioritized(NewRenderer(Options{}), 1000))))
+
+	var buf bytes.Buffer
+	if err := md.Convert([]byte("~~&**#27;**[31mFAKE~~"), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "\x1b[31m") {
+		t.Fatalf("rendered source terminal control: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "&#27;[31mFAKE") {
+		t.Fatalf("control reference was not preserved: %q", buf.String())
+	}
+}


### PR DESCRIPTION
Glamour calls `html.UnescapeString` on text reconstructed from Goldmark AST nodes. Numeric character references can therefore produce source-controlled terminal escape sequences in the rendered output.

Filtering individual source or AST segments is insufficient because parent nodes can reconstruct an entity across child boundaries before decoding it.

## Reproduction

```go
package main

import (
	"fmt"
	"strings"

	"charm.land/glamour/v2"
)

func main() {
	renderer, err := glamour.NewTermRenderer()
	if err != nil {
		panic(err)
	}

	output, err := renderer.Render("~~&**#27;**[31mFAKE~~")
	if err != nil {
		panic(err)
	}

	fmt.Printf("injected SGR present: %v\n", strings.Contains(output, "\x1b[31m"))
	fmt.Printf("output: %q\n", output)
}
```
The Markdown parser splits the entity across nested emphasis nodes, but the strikethrough renderer reconstructs it as:
`&#27;[31mFAKE`

`html.UnescapeString` then converts `&#27`; to ESC, producing:
`\x1b[31mFAKE`

## Expected
character references that decode to terminal controls remain literal or are neutralized.

## Actual
 the rendered output contains the source-generated SGR sequence.

Depending on the terminal and consuming application, this may enable forged formatting or hyperlinks, clipboard manipulation, and other terminal-state changes. aka this is potentially a security issue (low/medium priority)

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
