### PR TITLE
chore: fix misspelled identifiers and example output

### DIFF
--- a/ansi/elements.go
+++ b/ansi/elements.go
@@ -280,8 +280,8 @@ func (tr *ANSIRenderer) NewElement(node ast.Node, source []byte) Element {
 				href:     u,
 				linkType: linkTypeAuto,
 			}
-			if shortned, ok := autolink.Detect(u); ok {
-				tl.content = shortned
+			if shortened, ok := autolink.Detect(u); ok {
+				tl.content = shortened
 			}
 			text := linkWithSuffix(tl, ctx.table.tableLinks)
 

--- a/ansi/table_links.go
+++ b/ansi/table_links.go
@@ -135,8 +135,8 @@ func (e *TableElement) collectLinksAndImages(ctx RenderContext) error {
 				content:  linkDomain(uri),
 				linkType: linkTypeAuto,
 			}
-			if shortned, ok := autolink.Detect(uri); ok {
-				autoLink.content = shortned
+			if shortened, ok := autolink.Detect(uri); ok {
+				autoLink.content = shortened
 			}
 			links = append(links, autoLink)
 		case *ast.Image:

--- a/examples/artichokes/main.go
+++ b/examples/artichokes/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	// While we're at it, let's jot down the detected color profile in the
 	// markdown output while we're at it.
-	fmt.Fprintf(&buf, "\n\nBy the way, this was rendererd as _%s._\n", w.Profile)
+	fmt.Fprintf(&buf, "\n\nBy the way, this was rendered as _%s._\n", w.Profile)
 
 	// Okay, now let's render some markdown.
 	r, err := glamour.NewTermRenderer(glamour.WithEnvironmentConfig())


### PR DESCRIPTION
- `shortned` -> `shortened`: local variable in `ansi/elements.go` and `ansi/table_links.go` (introduced in c9af045)
- `rendererd` -> `rendered`: printed text in the `examples/artichokes` demo

Pure renames/typos, no behavior change; no golden files affected.
